### PR TITLE
chore: always call Comment()

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -124,7 +124,7 @@ func processEvent(eventInfo webhook.EventInfo) {
 	// send the commit status
 	github.Status(ctx, isPr, newStatus, statusDescription, eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.Sha, devMode)
 
-	if isPr && (changeCount > 0 || errorCount > 0 || unknownCount > 0) {
+	if isPr {
 		// if it's a pull-request event, only comment when something has happened
 		t := time.Now()
 		tStr := t.Format("3:04PM MST, 2 Jan 2006")

--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -163,7 +163,7 @@ func Comment(ctx context.Context, owner, repo string, prNum int, commentBodies [
 	}
 	for nextExistingCommentIdx < len(existingComments) {
 		existingComment := existingComments[nextExistingCommentIdx]
-		truncateCommentBody := "[Refreshed diff content is in above comments]\n\n" + commentIdentifier + "\n"
+		truncateCommentBody := "[Outdated argo-diff content]\n\n" + commentIdentifier + "\n"
 		newComment := github.IssueComment{Body: &truncateCommentBody}
 		issueComment, resp, err := commentClient.Issues.EditComment(ctx, owner, repo, *existingComment.ID, &newComment)
 		if resp != nil {

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -251,7 +251,7 @@ func TestCommentExistingMulti(t *testing.T) {
 	if *comments[1].ID != 4444444333 {
 		t.Errorf("2nd Comment ID doesn't match 4444444333: %d", *comments[1].ID)
 	}
-	if !strings.Contains(*comments[1].Body, "Refreshed diff content is in above comments") {
-		t.Errorf("1st Comment body doesn't match 'Refreshed diff content is in above comments': %s", *comments[1].Body)
+	if !strings.Contains(*comments[1].Body, "[Outdated argo-diff content]") {
+		t.Errorf("1st Comment body doesn't match '[Outdated argo-diff content]': %s", *comments[1].Body)
 	}
 }


### PR DESCRIPTION
In case a subsequent push makes it such that there are no argo app changes in the branch, make sure the Comment() is called so that the previous argo-diff comment is blanked out