### PR TITLE
fix: multiple comments from multiple app changes

### DIFF
--- a/internal/github/markdown.go
+++ b/internal/github/markdown.go
@@ -224,8 +224,8 @@ func (c CommentMarkdown) String() []string {
 			}
 		}
 		md += "</details>\n\n"
-		res = append(res, md)
 	}
+	res = append(res, md)
 	return res
 }
 


### PR DESCRIPTION
When multiple argo apps had changes, multiple/repetitive comments were being generated instead of a single comment