### PR TITLE
feat(chart): add command into the templated command and allow override

### DIFF
--- a/charts/argo-diff/templates/deployment.yaml
+++ b/charts/argo-diff/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: argo-diff
+          command: {{ .Values.command }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/argo-diff/values.yaml
+++ b/charts/argo-diff/values.yaml
@@ -19,6 +19,7 @@ config:
   # Should contain the following keys ARGOCD_AUTH_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, GITHUB_WEBHOOK_SECRET
   secretName: ""
 
+command: ["/app/argo-diff"]
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Discovered when manually editing deployment for testing that the command isn't specific on the pod. This means if changed outside the chart then argo or flux won't revert.