### PR TITLE
fix: nil pointer ref for apps w/ multi sources

### DIFF
--- a/internal/argocd/argocd_testdata/payload-GET-applications-brief.json
+++ b/internal/argocd/argocd_testdata/payload-GET-applications-brief.json
@@ -167,8 +167,7 @@
         "summary": {},
         "controllerNamespace": "argocd"
       }
-    },
-    {
+    }, {
       "metadata": {
         "name": "argo-diff",
         "namespace": "argocd",
@@ -254,6 +253,130 @@
             "kind": "IngressRoute",
             "namespace": "argocd",
             "name": "argocd-diff",
+            "status": "OutOfSync"
+          }
+        ],
+        "sync": {
+          "status": "OutOfSync",
+          "comparedTo": {
+            "source": {
+              "repoURL": "ssh://git@github.com/vince-riv/argo-diff.git",
+              "path": "k8s",
+              "targetRevision": "HEAD"
+            },
+            "destination": {
+              "server": "https://kubernetes.default.svc",
+              "namespace": "argocd"
+            }
+          },
+          "revision": "0341d95b8c70dc5f555fc8fe337e14b5496ff092"
+        },
+        "health": {
+          "status": "Healthy"
+        },
+        "reconciledAt": "2023-11-10T17:49:21Z",
+        "sourceType": "Kustomize",
+        "summary": {
+          "images": [
+            "123456478901.dkr.ecr.us-east-1.amazonaws.com/argo-diff:pr-1"
+          ]
+        },
+        "controllerNamespace": "argocd"
+      }
+    }, {
+      "metadata": {
+        "name": "argo-diff-multi",
+        "namespace": "argocd2",
+        "uid": "8aa5134a3-c334-46cd-a904-71e86bf8dd12",
+        "resourceVersion": "479656712",
+        "generation": 1,
+        "creationTimestamp": "2023-11-10T17:47:14Z",
+        "labels": {
+          "argocd.argoproj.io/instance": "argo-apps"
+        },
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"argoproj.io/v1alpha1\",\"kind\":\"Application\",\"metadata\":{\"annotations\":{},\"labels\":{\"argocd.argoproj.io/instance\":\"argo-apps\"},\"name\":\"argo-diff-multi\",\"namespace\":\"argocd2\"},\"spec\":{\"destination\":{\"namespace\":\"argocd2\",\"server\":\"https://kubernetes.default.svc\"},\"project\":\"argocd-extras\",\"source\":{\"path\":\"k8s\",\"repoURL\":\"ssh://git@github.com/vince-riv/argo-diff.git\",\"targetRevision\":\"HEAD\"},\"syncPolicy\":{}}}\n"
+        },
+        "managedFields": [
+          {
+            "manager": "argocd-controller",
+            "operation": "Update",
+            "apiVersion": "argoproj.io/v1alpha1",
+            "time": "2023-11-10T17:49:21Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {}
+          },
+          {
+            "manager": "argocd-application-controller",
+            "operation": "Update",
+            "apiVersion": "argoproj.io/v1alpha1",
+            "time": "2023-11-10T17:49:22Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {}
+          }
+        ]
+      },
+      "spec": {
+        "sources": [{
+          "repoURL": "https:://repo-hostname.dummy/charts",
+          "targetRevision": "1.2.3",
+          "chart": "argo-diff",
+          "helm": {
+            "passCredentials": true,
+            "valueFiles": ["$values/k8s/conf/values.yaml"]
+          }
+        },{
+          "repoURL": "ssh://git@github.com/vince-riv/argo-diff.git",
+          "targetRevision": "HEAD",
+          "ref": "values"
+        }],
+        "destination": {
+          "server": "https://kubernetes.default.svc",
+          "namespace": "argocd2"
+        },
+        "project": "argocd-extras",
+        "syncPolicy": {}
+      },
+      "status": {
+        "resources": [
+          {
+            "version": "v1",
+            "kind": "Service",
+            "namespace": "argocd2",
+            "name": "argo-diff-multi",
+            "status": "OutOfSync",
+            "health": {
+              "status": "Healthy"
+            }
+          },
+          {
+            "group": "apps",
+            "version": "v1",
+            "kind": "Deployment",
+            "namespace": "argocd2",
+            "name": "argo-diff-multi",
+            "status": "OutOfSync",
+            "health": {
+              "status": "Healthy"
+            }
+          },
+          {
+            "group": "bitnami.com",
+            "version": "v1alpha1",
+            "kind": "SealedSecret",
+            "namespace": "argocd2",
+            "name": "argo-diff-multi-env",
+            "status": "OutOfSync",
+            "health": {
+              "status": "Healthy"
+            }
+          },
+          {
+            "group": "traefik.containo.us",
+            "version": "v1alpha1",
+            "kind": "IngressRoute",
+            "namespace": "argocd2",
+            "name": "argocd-diff-multi",
             "status": "OutOfSync"
           }
         ],


### PR DESCRIPTION
filterApplications() wasn't properly handling cases when an Argo application had multiple sources defined.