### PR TITLE
fix: expose api client opts in env vars

### DIFF
--- a/charts/argo-diff/Chart.yaml
+++ b/charts/argo-diff/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.1"
+appVersion: "0.10.0"

--- a/charts/argo-diff/README.md
+++ b/charts/argo-diff/README.md
@@ -25,9 +25,12 @@ $ helm install my-release oci://ghcr.io/vince-riv/chart/argo-diff
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| config.argocdBaseURL | string | `""` | The base URL of the ArgoCD server. Through which the argo-diff app can communicate with argocd server. |
+| command[0] | string | `"/app/argo-diff"` |  |
+| config.argocdServerAddr | string | `""` | REQUIRED: hostname and/or port of the ArgoCD server (eg: argocd.domain.tld or argocd.domain.tld:8080) |
+| config.argocdServerInsecure | string | `"false"` | flag to enable/disable TLS verification when communicating to the ArgoCD server |
+| config.argocdServerPlainText | string | `"false"` | flag to enable/disable TLS negotiation (ie: set to true when the ArgoCD server does not have TLS/SSL) |
 | config.argocdUIBaseURL | string | `""` | The base URL of the ArgoCD UI. Used for link generation in comments |
-| config.secretName | string | `""` | The name of the secret that contains the argocd credentials. Should contain the following keys ARGOCD_AUTH_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, GITHUB_WEBHOOK_SECRET |
+| config.secretName | string | `""` | REQUIRED: The name of the secret that contains the argocd credentials. Should contain the following keys ARGOCD_AUTH_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, GITHUB_WEBHOOK_SECRET |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/vince-riv/argo-diff"` |  |
@@ -41,6 +44,7 @@ $ helm install my-release oci://ghcr.io/vince-riv/chart/argo-diff
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"},"initialDelaySeconds":2,"periodSeconds":10}` | Configuration for liveness check. (See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |

--- a/charts/argo-diff/templates/deployment.yaml
+++ b/charts/argo-diff/templates/deployment.yaml
@@ -45,10 +45,16 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
-          - name: ARGOCD_BASE_URL
-            value: {{ .Values.config.argocdBaseURL }}
+          - name: ARGOCD_SERVER_ADDR
+            value: "{{ .Values.config.argocdServerAddr }}"
+          - name: ARGOCD_SERVER_INSECURE
+            value: "{{ .Values.config.argocdServerInsecure }}"
+          - name: ARGOCD_SERVER_PLAINTEXT
+            value: "{{ .Values.config.argocdServerPlainText }}"
           - name: ARGOCD_UI_BASE_URL
-            value: {{ .Values.config.argocdUIBaseURL }}
+            value: "{{ .Values.config.argocdUIBaseURL }}"
+          - name: LOG_LEVEL
+            value: "{{ .Values.logLevel }}"
           envFrom:
             - secretRef:
                 name: {{ .Values.config.secretName }}

--- a/charts/argo-diff/values.yaml
+++ b/charts/argo-diff/values.yaml
@@ -11,15 +11,21 @@ image:
   tag: ""
 
 config:
-  # config.argocdBaseURL -- The base URL of the ArgoCD server. Through which the argo-diff app can communicate with argocd server.
-  argocdBaseURL: ""
+  # config.argocdServerAddr -- REQUIRED: hostname and/or port of the ArgoCD server (eg: argocd.domain.tld or argocd.domain.tld:8080)
+  argocdServerAddr: ""
+  # config.argocdServerInsecure -- flag to enable/disable TLS verification when communicating to the ArgoCD server
+  argocdServerInsecure: "false"
+  # config.argocdServerPlainText -- flag to enable/disable TLS negotiation (ie: set to true when the ArgoCD server does not have TLS/SSL)
+  argocdServerPlainText: "false"
   # config.argocdUIBaseURL -- The base URL of the ArgoCD UI. Used for link generation in comments
   argocdUIBaseURL: ""
-  # config.secretName -- The name of the secret that contains the argocd credentials.
+  # config.secretName -- REQUIRED: The name of the secret that contains the argocd credentials.
   # Should contain the following keys ARGOCD_AUTH_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, GITHUB_WEBHOOK_SECRET
   secretName: ""
 
 command: ["/app/argo-diff"]
+
+logLevel: info
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/vince-riv/argo-diff/internal/argocd"
 	"github.com/vince-riv/argo-diff/internal/server"
 )
 
@@ -70,11 +71,15 @@ func main() {
 	if os.Getenv("ARGOCD_AUTH_TOKEN") == "" {
 		log.Fatal().Msg("ARGOCD_AUTH_TOKEN environment variable not set")
 	}
-	if os.Getenv("ARGOCD_BASE_URL") == "" {
-		log.Fatal().Msg("ARGOCD_BASE_URL environment variable not set")
+	if os.Getenv("ARGOCD_SERVER_ADDR") == "" {
+		log.Fatal().Msg("ARGOCD_SERVER_ADDR environment variable not set")
 	}
 	if os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN") == "" {
 		log.Fatal().Msg("GITHUB_PERSONAL_ACCESS_TOKEN environment variable not set")
+	}
+
+	if err := argocd.ConnectivityCheck(); err != nil {
+		log.Fatal().Err(err).Msg("Connectivity check failed")
 	}
 
 	server.StartWebhookProcessor("", 8080, githubWebhookSecret, devMode)


### PR DESCRIPTION
As discussed in #42, this adds new environment variables to drive configuration of the ArgoCD server

Also adds a connectivity check prior to the web server getting started - if the ArgoCD API is not accessible within 30s it should fail to start. (Basically a workaround for #41)