### PR TITLE
fix: bubble up when argocd diff errs

### DIFF
--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -148,8 +148,8 @@ func GetApplicationChanges(ctx context.Context, eventInfo webhook.EventInfo) ([]
 		//}
 		appResChanges, err := getApplicationChanges(ctx, &app, eventInfo.Sha, nil, nil)
 		if err != nil {
-			// TODO why set WarnStr when appResChanges isn't appended?
 			appResChanges.WarnStr = fmt.Sprintf("Failed to diff application %s: %s", app.ObjectMeta.Name, err.Error())
+			appResList = append(appResList, appResChanges)
 		} else if len(appResChanges.ChangedResources) > 0 {
 			appResList = append(appResList, appResChanges)
 			appsWithChanges, err := argoAppsWithChanges(ctx, app.ObjectMeta.Name, appResChanges.ChangedResources, eventInfo.Sha)
@@ -205,8 +205,8 @@ func GetApplicationChanges(ctx context.Context, eventInfo webhook.EventInfo) ([]
 		}
 		appResChanges, err := getApplicationChanges(ctx, &app, "", revList, srcPos)
 		if err != nil {
-			// TODO why set WarnStr when appResChanges isn't appended?
 			appResChanges.WarnStr = fmt.Sprintf("Failed to diff application %s: %s", app.ObjectMeta.Name, err.Error())
+			appResList = append(appResList, appResChanges)
 		} else if len(appResChanges.ChangedResources) > 0 {
 			appResList = append(appResList, appResChanges)
 		}

--- a/internal/github/markdown.go
+++ b/internal/github/markdown.go
@@ -217,7 +217,7 @@ func (a ArgoAppMarkdown) OverviewStr(continued bool) string {
 	md += syncString(a.SyncStatus) + "\n"
 	md += healthString(a.HealthStatus, a.HealthMsg) + "\n\n"
 	if a.WarnStr != "" {
-		md += a.WarnStr + "\n\n"
+		md += "```\n" + a.WarnStr + "```\n\n"
 	}
 	return md
 }


### PR DESCRIPTION
When `argocd diff app ...` fails, the error wasn't displayed in the PR