### PR TITLE
feat: inspect manifest-generate-paths annotation

### DIFF
--- a/internal/argocd/filter_manifest_paths.go
+++ b/internal/argocd/filter_manifest_paths.go
@@ -1,0 +1,114 @@
+package argocd
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/rs/zerolog/log"
+)
+
+// containsGlob returns true if the pattern contains glob meta characters.
+func containsGlob(pattern string) bool {
+	return strings.ContainsAny(pattern, "*?[")
+}
+
+// matchChangedFiles checks if any of the changed files match one of the given patterns.
+func matchChangedFiles(changedFiles []string, patterns []string) bool {
+	for _, file := range changedFiles {
+		// changed files shouldn't have absolute paths, but we'll trim / to be safe
+		if filepath.IsAbs(file) {
+			file = strings.TrimPrefix(file, "/")
+		}
+		for _, pattern := range patterns {
+			log.Trace().Msgf("matchChangedFiles(): matching files %s to pattern %s", file, pattern)
+			if containsGlob(pattern) {
+				// filepath.Match expects the pattern to match the entire name.
+				if ok, err := filepath.Match(pattern, file); err == nil && ok {
+					return true
+				} else if err != nil {
+					log.Warn().Err(err).Msgf("failed to call filepath.Match(%s, %s)", pattern, file)
+				}
+			} else {
+				// For a non-glob pattern, treat it as a directory prefix.
+				dirPrefix := pattern
+				if !strings.HasSuffix(dirPrefix, string(filepath.Separator)) {
+					dirPrefix += string(filepath.Separator)
+				}
+				// Clean paths to avoid mismatches.
+				cleanFile := filepath.Clean(file)
+				cleanPrefix := filepath.Clean(dirPrefix)
+				// Check if the changed file is under the directory.
+				if strings.HasPrefix(cleanFile, cleanPrefix) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// FilterApplications returns a list of Application objects whose annotation-based manifest-generate-paths
+// or default source path (if the annotation is absent) match one or more of the changed files.
+// It iterates through each source returned by the built-in GetSources() method.
+func FilterApplicationsByPath(apps []v1alpha1.Application, changedFiles []string) []v1alpha1.Application {
+	var matchedApps []v1alpha1.Application
+
+	for _, app := range apps {
+		annotations := app.GetAnnotations()
+		var manifestPaths string
+		var ok bool
+		if manifestPaths, ok = annotations["argocd.argoproj.io/manifest-generate-paths"]; !ok {
+			// if the app does not have this annotation, include it in the results
+			matchedApps = append(matchedApps, app)
+			continue
+		}
+
+		// Get all sources from the Application.
+		sources := app.Spec.GetSources()
+		matched := false
+
+		for _, source := range sources {
+			var patterns []string
+
+			if manifestPaths != "" {
+				// Split the annotation on semicolons and build full patterns.
+				parts := strings.Split(manifestPaths, ";")
+				for _, p := range parts {
+					p = strings.TrimSpace(p)
+					if p == "" {
+						continue
+					}
+					var fullPattern string
+					if !filepath.IsAbs(p) {
+						// If p is not an absolute path, join it with the source's path.
+						if p == "." {
+							fullPattern = source.Path
+						} else if strings.HasPrefix(p, "./") {
+							fullPattern = filepath.Join(source.Path, strings.TrimPrefix(p, "./"))
+						} else {
+							fullPattern = filepath.Join(source.Path, p)
+						}
+					} else {
+						fullPattern = strings.TrimPrefix(p, "/")
+					}
+					patterns = append(patterns, fullPattern)
+				}
+			} else {
+				// Empty annotation, include it in the results
+				matched = true
+			}
+
+			if matchChangedFiles(changedFiles, patterns) {
+				matched = true
+				break // No need to check further sources for this Application.
+			}
+		}
+
+		if matched {
+			matchedApps = append(matchedApps, app)
+		}
+	}
+
+	return matchedApps
+}

--- a/internal/argocd/filter_manifest_paths_test.go
+++ b/internal/argocd/filter_manifest_paths_test.go
@@ -1,0 +1,98 @@
+package argocd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+)
+
+func TestFilterApplicationsByPath(t *testing.T) {
+	var a []v1alpha1.Application
+	annotationStr := "argocd.argoproj.io/manifest-generate-paths"
+	payload, _, err := readFileToByteArray(payloadAppList)
+	if err != nil {
+		t.Errorf("Failed to read %s: %v", payloadAppList, err)
+	}
+	var appList v1alpha1.ApplicationList
+	if err := json.Unmarshal(payload, &appList); err != nil {
+		t.Errorf("Error decoding ApplicationList payload: %v", err)
+	}
+	a = appList.Items
+	if err != nil {
+		t.Errorf("decodeApplicationListPayload() failed: %s", err)
+	}
+
+	// no annotations set, should get the same apps back
+	passThru := FilterApplicationsByPath(a, []string{"doesnt", "matter"})
+	if len(passThru) != len(a) {
+		t.Error("passthrough failed for FilterApplicationByPath()")
+	}
+
+	a1 := []v1alpha1.Application{a[0]}
+	a1[0].SetAnnotations(map[string]string{
+		annotationStr: ".",
+	})
+
+	relativeNoMatch := FilterApplicationsByPath(a1, []string{"not_apps/manifest.yaml", "something/else.yaml"})
+	if len(relativeNoMatch) != 0 {
+		t.Error("relativeNoMatch failed")
+	}
+
+	relativeMatch := FilterApplicationsByPath(a1, []string{"apps/somepath/manifest.yaml", "something/else.yaml"})
+	if len(relativeMatch) != 1 {
+		t.Error("relativeMatch failed")
+	}
+
+	a1[0].SetAnnotations(map[string]string{
+		annotationStr: "/apps",
+	})
+
+	absoluteNoMatch := FilterApplicationsByPath(a1, []string{"not_apps/manifest.yaml", "something/else.yaml"})
+	if len(absoluteNoMatch) != 0 {
+		t.Error("absoluteNoMatch failed")
+	}
+
+	absoluteMatch := FilterApplicationsByPath(a1, []string{"apps/somepath/manifest.yaml", "something/else.yaml"})
+	if len(absoluteMatch) != 1 {
+		t.Error("absoluteMatch failed")
+	}
+
+	a1[0].SetAnnotations(map[string]string{
+		annotationStr: "/shared/application-*.yaml",
+	})
+
+	globNoMatch := FilterApplicationsByPath(a1, []string{"somepath/application-testing.yaml", "something/else.yaml"})
+	if len(globNoMatch) != 0 {
+		t.Error("globNoMatch failed")
+	}
+
+	globMatch := FilterApplicationsByPath(a1, []string{"shared/application-testing_123.yaml", "something/else.yaml"})
+	if len(globMatch) != 1 {
+		t.Error("globMatch failed")
+	}
+
+	a1[0].SetAnnotations(map[string]string{
+		annotationStr: ".;/shared/application-*.yaml;/more/apps/",
+	})
+
+	mixedNoMatch := FilterApplicationsByPath(a1, []string{"somepath/application-testing.yaml", "something/else.yaml", "more/notapps/manifest.yaml"})
+	if len(mixedNoMatch) != 0 {
+		t.Error("mixedNoMatch failed")
+	}
+
+	mixedMatch1 := FilterApplicationsByPath(a1, []string{"shared/application-testing.yaml", "something/else.yaml", "more/notapps/manifest.yaml"})
+	if len(mixedMatch1) != 1 {
+		t.Error("mixedMatch1 failed")
+	}
+
+	mixedMatch2 := FilterApplicationsByPath(a1, []string{"somepath/application-testing.yaml", "apps/manifest.yaml", "more/notapps/manifest.yaml"})
+	if len(mixedMatch2) != 1 {
+		t.Error("mixedMatch2 failed")
+	}
+
+	mixedMatch3 := FilterApplicationsByPath(a1, []string{"somepath/application-testing.yaml", "something/else/dot.yaml", "more/apps/manifest.yaml"})
+	if len(mixedMatch3) != 1 {
+		t.Error("mixedMatch3 failed")
+	}
+}

--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -239,6 +239,11 @@ func filterApplications(a []v1alpha1.Application, eventInfo webhook.EventInfo, m
 			}
 		}
 	}
+	if len(eventInfo.ChangedFiles) > 0 {
+		log.Debug().Msg("Attempting to filter applications based on manifest-generate-paths annotation")
+		return FilterApplicationsByPath(appList, eventInfo.ChangedFiles), nil
+	}
+	log.Debug().Msg("No changed files in event info; skipping check for manifest-generate-paths")
 	return appList, nil
 }
 

--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -122,13 +122,33 @@ func getCommentUser(ctx context.Context) error {
 func GetPullRequest(ctx context.Context, owner, repo string, prNum int) (*github.PullRequest, error) {
 	pr, resp, err := commentClient.PullRequests.Get(ctx, owner, repo, prNum)
 	if resp != nil {
-		log.Info().Msgf("%s received when calling client.Users.Get() via go-github", resp.Status)
+		log.Info().Msgf("%s received when calling commentClient.PullRequests.Get() via go-github", resp.Status)
 	}
 	if err != nil {
 		log.Error().Err(err).Msgf("Unable to fetch pull request %s/%s#%d", owner, repo, prNum)
 		return nil, err
 	}
 	return pr, nil
+}
+
+// Returns list of files in a pull request
+func ListPullRequestFiles(ctx context.Context, owner, repo string, prNum int) ([]string, error) {
+	var fileList []string
+	cfs, resp, err := commentClient.PullRequests.ListFiles(ctx, owner, repo, prNum, nil)
+	if resp != nil {
+		log.Info().Msgf("%s received when calling commentClient.PullRequests.ListFiles() via go-github", resp.Status)
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, cf := range cfs {
+		if cf != nil && cf.Filename != nil {
+			fileList = append(fileList, *cf.Filename)
+		} else {
+			log.Warn().Msgf("nil value found in call to list files in pull request %s/%s#%d", owner, repo, prNum)
+		}
+	}
+	return fileList, nil
 }
 
 // Returns true if sha is HEAD of the pull request

--- a/internal/process_event/code_change.go
+++ b/internal/process_event/code_change.go
@@ -34,21 +34,29 @@ func ProcessCodeChange(eventInfo webhook.EventInfo, devMode bool, wg *sync.WaitG
 	defer cancel()
 
 	isPr := eventInfo.PrNum > 0
-	if isPr && eventInfo.Refresh {
-		pull, err := github.GetPullRequest(ctx, eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
+	if isPr {
+		if eventInfo.Refresh {
+			pull, err := github.GetPullRequest(ctx, eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
+			if err != nil {
+				log.Error().Err(err).Msgf("github.GetPullRequest(%s, %s, %d) failed", eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
+				return
+			}
+			base := pull.GetBase()
+			head := pull.GetHead()
+			if base == nil || head == nil {
+				log.Error().Msgf("Empty branch information when refreshing %s/%s#%d", eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
+				return
+			}
+			eventInfo.Sha = *head.SHA
+			eventInfo.ChangeRef = *head.Ref
+			eventInfo.BaseRef = *base.Ref
+		}
+		changedFiles, err := github.ListPullRequestFiles(ctx, eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
 		if err != nil {
-			log.Error().Err(err).Msgf("github.GetPullRequest(%s, %s, %d) failed", eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
-			return
+			log.Error().Err(err).Msgf("Failed to list pull request files for %s/%s#%d", eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
+		} else {
+			eventInfo.ChangedFiles = changedFiles
 		}
-		base := pull.GetBase()
-		head := pull.GetHead()
-		if base == nil || head == nil {
-			log.Error().Msgf("Empty branch information when refreshing %s/%s#%d", eventInfo.RepoOwner, eventInfo.RepoName, eventInfo.PrNum)
-			return
-		}
-		eventInfo.Sha = *head.SHA
-		eventInfo.ChangeRef = *head.Ref
-		eventInfo.BaseRef = *base.Ref
 	}
 
 	// set commit status to PENDING

--- a/internal/webhook/process.go
+++ b/internal/webhook/process.go
@@ -12,15 +12,16 @@ import (
 
 // Data structure for information passed by github webhook events
 type EventInfo struct {
-	Ignore         bool   `json:"ignore"`
-	RepoOwner      string `json:"owner"`
-	RepoName       string `json:"repo"`
-	RepoDefaultRef string `json:"default_ref"`
-	Sha            string `json:"commit_sha"`
-	PrNum          int    `json:"pr"`
-	ChangeRef      string `json:"change_ref"`
-	BaseRef        string `json:"base_ref"`
-	Refresh        bool   `json:"refresh"`
+	Ignore         bool     `json:"ignore"`
+	RepoOwner      string   `json:"owner"`
+	RepoName       string   `json:"repo"`
+	RepoDefaultRef string   `json:"default_ref"`
+	Sha            string   `json:"commit_sha"`
+	PrNum          int      `json:"pr"`
+	ChangeRef      string   `json:"change_ref"`
+	BaseRef        string   `json:"base_ref"`
+	Refresh        bool     `json:"refresh"`
+	ChangedFiles   []string `json:"changed_files,omitempty"`
 }
 
 func NewEventInfo() EventInfo {


### PR DESCRIPTION
When `argocd.argoproj.io/manifest-generate-paths` [annotation](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#webhook-and-manifest-paths-annotation) is specified on ArgoCD Applications, compare its values with the files-changed list of a pull request and only produce diffs for matching applications.

This improves performance and reduces chattiness in mono repos.

Closes #12