### PR TITLE
Support fully qualified git references in ArgoCD targetRevision

### DIFF
--- a/internal/argocd/application.go
+++ b/internal/argocd/application.go
@@ -13,8 +13,8 @@ type Application struct {
 }
 
 type ApplicationSpec struct {
-	Source     *ApplicationSource   `json:"source,omitempty"`
-	Sources    []ApplicationSource  `json:"sources,omitempty"`
+	Source     *ApplicationSource  `json:"source,omitempty"`
+	Sources    []ApplicationSource `json:"sources,omitempty"`
 	SyncPolicy *SyncPolicy         `json:"syncPolicy,omitempty"`
 }
 

--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -264,10 +264,21 @@ func gitRepoMatch(repoUrl, repoOwner, repoName string) bool {
 	return false
 }
 
+// normalizeBranchRef strips the fully-qualified refs/heads/ prefix so a
+// fully-qualified targetRevision (refs/heads/main) — ArgoCD's recommended
+// form per its high-availability guide — compares equal to the short
+// branch names GitHub supplies in webhook events (main). Tag refs
+// (refs/tags/...) and non-branch refs are left untouched, since PR base
+// refs are always branches and would never match a tag.
+func normalizeBranchRef(ref string) string {
+	return strings.TrimPrefix(ref, "refs/heads/")
+}
+
 func checkSource(appSpecSource ApplicationSource, appName string, eventInfo webhook.EventInfo, automatedSync bool) bool {
 	baseRef := eventInfo.BaseRef
 	changeRef := eventInfo.ChangeRef
 	repoDefaultRef := eventInfo.RepoDefaultRef
+	targetRevision := normalizeBranchRef(appSpecSource.TargetRevision)
 	log.Trace().Msgf("checkSource() - appname: %s (autosync %t)", appName, automatedSync)
 	log.Trace().Msgf("checkSource() - appSpecSource: %+v", appSpecSource)
 	log.Trace().Msgf("checkSource() - eventInfo: %+v", eventInfo)
@@ -281,12 +292,12 @@ func checkSource(appSpecSource ApplicationSource, appName string, eventInfo webh
 	}
 	if baseRef != "" {
 		// Processing a PR ...
-		if appSpecSource.TargetRevision == "HEAD" && baseRef != repoDefaultRef {
+		if targetRevision == "HEAD" && baseRef != repoDefaultRef {
 			// filter application if argo targets repo default (eg: main) and PR is not targetting main
 			log.Debug().Msgf("Filtering application %s: Target Rev is HEAD; baseRef %s != repoDefaultRef %s", appName, baseRef, repoDefaultRef)
 			return false
 		}
-		if appSpecSource.TargetRevision != "HEAD" && baseRef != appSpecSource.TargetRevision {
+		if targetRevision != "HEAD" && baseRef != targetRevision {
 			// filter application if argo doesn't target repo default (eg: main)  and PR is not targetting that branch
 			log.Debug().Msgf("Filtering application %s: baseRef %s != Target Rev %s", appName, baseRef, appSpecSource.TargetRevision)
 			return false
@@ -294,13 +305,13 @@ func checkSource(appSpecSource ApplicationSource, appName string, eventInfo webh
 	} else {
 		// processing a push
 		// eg: refs/heads/main -> main
-		changeRef = strings.TrimPrefix(changeRef, "refs/heads/")
+		changeRef = normalizeBranchRef(changeRef)
 		// filter out apps where auto-sync is enabled for the branch of the push
-		if appSpecSource.TargetRevision == "HEAD" && changeRef == repoDefaultRef && automatedSync {
+		if targetRevision == "HEAD" && changeRef == repoDefaultRef && automatedSync {
 			log.Debug().Msgf("Filtering auto-sync application %s: Target Rev is HEAD; changeRef %s == repoDefaultRef %s", appName, changeRef, repoDefaultRef)
 			return false
 		}
-		if appSpecSource.TargetRevision != "HEAD" && changeRef == appSpecSource.TargetRevision && automatedSync {
+		if targetRevision != "HEAD" && changeRef == targetRevision && automatedSync {
 			log.Debug().Msgf("checkSource() - Filtering auto-sync application %s: changeRef %s = Target Rev %s", appName, changeRef, appSpecSource.TargetRevision)
 			return false
 		}

--- a/internal/argocd/helper_test.go
+++ b/internal/argocd/helper_test.go
@@ -114,6 +114,78 @@ func TestFilterApplications(t *testing.T) {
 	}
 }
 
+func TestFilterApplicationsFullyQualifiedRefs(t *testing.T) {
+	loadApps := func(t *testing.T) []Application {
+		payload, _, err := readFileToByteArray(payloadAppList)
+		if err != nil {
+			t.Fatalf("Failed to read %s: %v", payloadAppList, err)
+		}
+		var appList ApplicationList
+		if err := json.Unmarshal(payload, &appList); err != nil {
+			t.Fatalf("Error decoding ApplicationList payload: %v", err)
+		}
+		return appList.Items
+	}
+
+	// targetRevision = refs/heads/main, PR base main should match even though
+	// the PR's change branch is unrelated.
+	a := loadApps(t)
+	a[1].Spec.Source.TargetRevision = "refs/heads/main"
+	evtInfo := wh.EventInfo{RepoOwner: "vince-riv", RepoName: "argo-diff", RepoDefaultRef: "main", ChangeRef: "dev", BaseRef: "main"}
+	result, _ := filterApplications(a, evtInfo, false)
+	if len(result) != 1 {
+		t.Error("PR against main should have matched (targetRev refs/heads/main)")
+	}
+
+	// targetRevision = refs/heads/dev
+	a = loadApps(t)
+	a[1].Spec.Source.TargetRevision = "refs/heads/dev"
+	evtInfo = wh.EventInfo{RepoOwner: "vince-riv", RepoName: "argo-diff", RepoDefaultRef: "main", ChangeRef: "dev", BaseRef: "dev"}
+	result, _ = filterApplications(a, evtInfo, false)
+	if len(result) != 1 {
+		t.Error("PR against dev should have matched (targetRev refs/heads/dev)")
+	}
+	evtInfo = wh.EventInfo{RepoOwner: "vince-riv", RepoName: "argo-diff", RepoDefaultRef: "main", ChangeRef: "dev", BaseRef: "main"}
+	result, _ = filterApplications(a, evtInfo, false)
+	if len(result) != 0 {
+		t.Error("PR against main should NOT have matched (targetRev refs/heads/dev)")
+	}
+
+	// Push to refs/heads/main w/ auto-sync enabled should be filtered out,
+	// same as the short-name case.
+	a = loadApps(t)
+	a[1].Spec.Source.TargetRevision = "refs/heads/main"
+	a[1].Spec.SyncPolicy = &SyncPolicy{Automated: &SyncPolicyAutomated{}}
+	evtInfo = wh.EventInfo{RepoOwner: "vince-riv", RepoName: "argo-diff", RepoDefaultRef: "main", ChangeRef: "refs/heads/main", BaseRef: ""}
+	result, _ = filterApplications(a, evtInfo, false)
+	if len(result) != 0 {
+		t.Error("Push to main should NOT have matched (targetRev refs/heads/main) (auto-sync ENABLED)")
+	}
+
+	// Sanity: tag refs are not treated as branches.
+	a = loadApps(t)
+	a[1].Spec.Source.TargetRevision = "refs/tags/v1.0.0"
+	evtInfo = wh.EventInfo{RepoOwner: "vince-riv", RepoName: "argo-diff", RepoDefaultRef: "main", ChangeRef: "dev", BaseRef: "v1.0.0"}
+	result, _ = filterApplications(a, evtInfo, false)
+	if len(result) != 0 {
+		t.Error("PR against a tag name should NOT have matched (targetRev refs/tags/v1.0.0)")
+	}
+}
+
+func TestNormalizeBranchRef(t *testing.T) {
+	cases := map[string]string{
+		"refs/heads/main": "main",
+		"HEAD":            "HEAD",
+		"refs/tags/v1":    "refs/tags/v1",
+		"main":            "main",
+	}
+	for in, want := range cases {
+		if got := normalizeBranchRef(in); got != want {
+			t.Errorf("normalizeBranchRef(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestFilterApplicationsMultiSource(t *testing.T) {
 	var a []Application
 


### PR DESCRIPTION
## Summary
- Normalize a fully-qualified branch ref (`refs/heads/<branch>`) in an Application's `targetRevision` so it compares equal to the short branch names GitHub supplies in webhook events, per ArgoCD's [high-availability guide](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#use-fully-qualified-git-references) recommendation.
- Without this fix, an Application with `targetRevision: refs/heads/main` would never match a PR/push against `main`, silently skipping the diff comment.

## Test plan
- [x] `go build -v ./...`
- [x] `go test ./...`
- [x] `go vet ./...` / `go fmt ./...`
- [x] Added unit tests in `internal/argocd/helper_test.go` covering PR/push matching against fully-qualified branch refs, auto-sync filtering, and tag-ref sanity check
- [ ] Follow-up PR: add k3s.yml e2e happy-path coverage for this configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)