### PR TITLE
fix: fail commit status and GitHub Action on manifest-generation errors

### DIFF
--- a/internal/argocd/argocd_client.go
+++ b/internal/argocd/argocd_client.go
@@ -229,10 +229,7 @@ func diffApplication(ctx context.Context, appName string, revision string, revis
 	output, err := execArgoCdCli(ctx, args)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if exitErr.ExitCode() == 1 {
-				if len(output) == 0 {
-					output = exitErr.Stderr
-				}
+			if exitErr.ExitCode() == 1 && len(output) > 0 {
 				log.Trace().Msgf("Application %s revision %s has changes: %s", appName, revision, output)
 				for _, diffStr := range diffBytesToStr(output) {
 					var appRes AppResource

--- a/internal/argocd/argocd_client_test.go
+++ b/internal/argocd/argocd_client_test.go
@@ -1,8 +1,24 @@
 package argocd
 
 import (
+	"context"
+	"os/exec"
 	"testing"
 )
+
+// makeExitError runs a trivial failing command to obtain a real *exec.ExitError
+// with exit code 1, then stamps the given stderr onto it for test purposes.
+func makeExitError(t *testing.T, stderr []byte) *exec.ExitError {
+	t.Helper()
+	cmd := exec.Command("false")
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError from running 'false', got %T: %v", err, err)
+	}
+	exitErr.Stderr = stderr
+	return exitErr
+}
 
 var lokiClusterRoleDiff = `===== rbac.authorization.k8s.io/ClusterRoleBinding /loki-clusterrolebinding ======
 --- /var/folders/4h/55t7qz1s27d2dpzp1dvcm5h40000gp/T/argocd-diff1365729858/loki-clusterrolebinding-live.yaml	2024-12-15 21:55:28
@@ -155,6 +171,41 @@ func TestExtractKubernetesFields(t *testing.T) {
 	if name != "loki-clusterrole" {
 		t.Errorf("Expected name 'loki-clusterrole', got %s", name)
 	}
+}
+
+func TestDiffApplicationExitCodeHandling(t *testing.T) {
+	originalExecArgoCdCli := execArgoCdCli
+	defer func() { execArgoCdCli = originalExecArgoCdCli }()
+
+	t.Run("exit 1 with stdout diff is treated as changes", func(t *testing.T) {
+		diffOutput := []byte(lokiClusterRoleDiff)
+		execArgoCdCli = func(ctx context.Context, args []string) ([]byte, error) {
+			return diffOutput, makeExitError(t, nil)
+		}
+		appResList, err := diffApplication(context.Background(), "argo-diff", "HEAD", nil, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if len(appResList) != 1 {
+			t.Fatalf("expected 1 changed resource, got %d", len(appResList))
+		}
+		if appResList[0].Kind != "ClusterRoleBinding" {
+			t.Errorf("expected kind ClusterRoleBinding, got %s", appResList[0].Kind)
+		}
+	})
+
+	t.Run("exit 1 with empty stdout and stderr is treated as a render failure", func(t *testing.T) {
+		execArgoCdCli = func(ctx context.Context, args []string) ([]byte, error) {
+			return nil, makeExitError(t, []byte("FATA[0000] failed to generate manifest"))
+		}
+		appResList, err := diffApplication(context.Background(), "argo-diff", "HEAD", nil, nil)
+		if err == nil {
+			t.Fatal("expected an error for exit 1 with empty stdout, got nil")
+		}
+		if appResList != nil {
+			t.Errorf("expected nil appResList on error, got %v", appResList)
+		}
+	})
 }
 
 func TestAppManifestHelper(t *testing.T) {

--- a/internal/process_event/code_change.go
+++ b/internal/process_event/code_change.go
@@ -129,6 +129,7 @@ func ProcessCodeChange(eventInfo webhook.EventInfo, devMode bool, wg *sync.WaitG
 		// if we had errors, commit status should be a failure
 		newStatus = github.StatusFailure
 		statusDescription = fmt.Sprintf("%s; %d had an error; first error: %s", changeCountStr, errorCount, firstError)
+		*callerErr = fmt.Errorf("%d application(s) failed to generate a diff; first error: %s", errorCount, firstError)
 	} else if firstError != "" {
 		// if we had a recoverable error, commit status can be a success (but let's give them the first error)
 		newStatus = github.StatusSuccess


### PR DESCRIPTION
## Summary
- Propagate app-diff errors (`errorCount > 0`) to the returned caller error in `ProcessCodeChange`, so `ProcessGithubAction`/`ProcessFileEvent` return non-nil and `cmd/main.go` exits non-zero. Actions mode previously always exited 0 even when an app's manifests failed to render. Commit status and PR comment behavior is unchanged.
- Harden `diffApplication`'s exit-code handling: `argocd app diff` exit code 1 is only treated as "has changes" when stdout is non-empty. Previously, a fatal render error (exit 1, empty stdout, error on stderr) was misread as a diff and reported as a phantom "success" change instead of a failure.
- Out-of-sync/degraded apps are unaffected — those remain `success` since sync/health status is display-only.

## Test plan
- [x] `go build -v ./...`
- [x] `go fmt ./...`
- [x] `go test -v ./...` — added `TestDiffApplicationExitCodeHandling` covering both the real-diff-on-stdout and empty-stdout-render-failure branches
- [ ] End-to-end verification via `.github/workflows/k3s.yml` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)