### PR TITLE
test: add k3s e2e coverage for manifest-generation-failure exit code

### DIFF
--- a/.github/workflows/k3s.yml
+++ b/.github/workflows/k3s.yml
@@ -156,60 +156,47 @@ jobs:
           echo "--- App List ---"
           argocd app list
 
-      - name: Run argo-diff as a standalone pod
-        id: argo_diff
+      - name: Run argo-diff (healthy)
+        id: argo_diff_healthy
         timeout-minutes: 2
+        env:
+          POD_NAME_PREFIX: argo-diff-healthy
+          IMAGE_TAG: ${{ steps.pr_info.outputs.IMAGE_TAG }}
+          ARGO_DIFF_CONTEXT_STR: ephemeral-environment-test
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          GITHUB_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_REF: ${{ steps.pr_info.outputs.PR_REF }}
+          EXPECT_EXIT: "0"
+        run: test/run-argo-diff-pod.sh
+
+      - name: Swap in failing ArgoCD application
+        id: argo_diff_swap
+        timeout-minutes: 1
         run: |
-          pod_name=argo-diff-$(date +%s)
-          cat <<EOF | kubectl -n argocd apply -f -
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: $pod_name
-          spec:
-            restartPolicy: Never
-            containers:
-              - name: argo-diff
-                command:
-                  - /app/argo-diff
-                image: ghcr.io/vince-riv/argo-diff:${{ steps.pr_info.outputs.IMAGE_TAG }}
-                env:
-                  - name: ARGO_DIFF_COMMENT_PREAMBLE
-                    value: |
-                      ## Argo-Diff - Ephemeral Environment Test
-                      This argo-diff should have the same output every run
-                  - name: ARGO_DIFF_CONTEXT_STR
-                    value: ephemeral-environment-test
-                  - name: ARGO_DIFF_SKIP_REF_CHECK
-                    value: "true"
-                  - name: ARGOCD_AUTH_TOKEN
-                    value: dummy_value
-                  - name: ARGOCD_SERVER_ADDR
-                    value: argocd-server.argocd.svc.cluster.local:80
-                  - name: ARGOCD_SERVER_INSECURE
-                    value: "true"
-                  - name: ARGOCD_SERVER_PLAINTEXT
-                    value: "true"
-                  - name: GITHUB_ACTIONS
-                    value: "true"
-                  - name: GITHUB_TOKEN
-                    value: ${{ secrets.GITHUB_TOKEN }}
-                  - name: GITHUB_SHA
-                    value: ${{ github.event.workflow_run.head_sha || github.sha }}
-                  - name: GITHUB_REF
-                    value: ${{ steps.pr_info.outputs.PR_REF }}
-                  - name: GITHUB_EVENT_NAME
-                    value: "pull_request"
-                  - name: GITHUB_HEAD_REF
-                    value: ${{ steps.pr_info.outputs.HEAD_REF }}
-                  - name: GITHUB_BASE_REF
-                    value: "k3s-test"
-                  - name: GITHUB_REPOSITORY
-                    value: ${{ github.repository }}
-                  - name: REPO_DEFAULT_REF
-                    value: "k3s-test"
-                  - name: LOG_LEVEL
-                    value: "debug"
-          EOF
-          kubectl -n argocd wait --for=condition=ready pod/$pod_name --timeout=60s
-          kubectl -n argocd logs -f $pod_name --pod-running-timeout=60s
+          # meta has selfHeal: true and would resurrect the apps we're about to
+          # delete, so neutralize it first. Its children carry no finalizers
+          # and delete instantly.
+          kubectl -n argocd patch application meta --type=merge -p '{"metadata":{"finalizers":null}}'
+          kubectl -n argocd delete application meta --ignore-not-found
+          kubectl -n argocd delete application basic-deployment helm-deployment --ignore-not-found
+          kubectl -n argocd apply -f test/argocd-broken-app.yaml --server-side=true
+          echo "--- App List ---"
+          argocd app list
+
+      - name: Run argo-diff (manifest failure)
+        id: argo_diff_failure
+        timeout-minutes: 2
+        env:
+          POD_NAME_PREFIX: argo-diff-failure
+          IMAGE_TAG: ${{ steps.pr_info.outputs.IMAGE_TAG }}
+          ARGO_DIFF_CONTEXT_STR: ephemeral-environment-test-failure
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          GITHUB_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_REF: ${{ steps.pr_info.outputs.PR_REF }}
+          EXPECT_EXIT: nonzero
+          REQUIRE_LOG: "Failed to diff application broken-deployment"
+        run: test/run-argo-diff-pod.sh

--- a/test/argocd-broken-app.yaml
+++ b/test/argocd-broken-app.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: broken
+  # Finalizer that ensures that project is not deleted until it is not referenced by any application
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Broken-app project (used to exercise argo-diff's manifest-generation-failure handling)
+  sourceRepos:
+    - 'https://github.com/vince-riv/argo-diff.git'
+  destinations:
+    - namespace: 'broken-deployment'
+      server: https://kubernetes.default.svc
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: broken-deployment
+spec:
+  project: broken
+  source:
+    repoURL: 'https://github.com/vince-riv/argo-diff.git'
+    targetRevision: k3s-test
+    # Deliberately nonexistent: argocd app diff fails to render manifests for this app,
+    # which is what proves argo-diff exits non-zero on manifest-generation errors.
+    path: test/does-not-exist
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: broken-deployment

--- a/test/run-argo-diff-pod.sh
+++ b/test/run-argo-diff-pod.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Runs argo-diff as a standalone pod against the k3s test cluster, waits for it
+# to terminate, and asserts its exit code (and optionally its logs).
+#
+# Required env vars:
+#   POD_NAME_PREFIX       - prefix for the pod name (a timestamp suffix is appended)
+#   IMAGE_TAG             - argo-diff image tag to run
+#   ARGO_DIFF_CONTEXT_STR - value for ARGO_DIFF_CONTEXT_STR (commit status / comment context)
+#   GITHUB_SHA            - commit sha argo-diff should diff against
+#   GITHUB_HEAD_REF       - PR head branch
+#   GITHUB_REPOSITORY     - owner/repo
+#   GITHUB_TOKEN          - GitHub token for commenting/status
+#   PR_REF                - GITHUB_REF value (e.g. refs/pull/N/merge)
+#   EXPECT_EXIT           - "0" to require success, "nonzero" to require failure
+#
+# Optional env vars:
+#   REQUIRE_LOG           - substring that must appear in the pod logs
+
+set -euo pipefail
+
+: "${POD_NAME_PREFIX:?}" "${IMAGE_TAG:?}" "${ARGO_DIFF_CONTEXT_STR:?}" \
+  "${GITHUB_SHA:?}" "${GITHUB_HEAD_REF:?}" "${GITHUB_REPOSITORY:?}" \
+  "${GITHUB_TOKEN:?}" "${PR_REF:?}" "${EXPECT_EXIT:?}"
+
+pod_name="${POD_NAME_PREFIX}-$(date +%s)"
+
+cat <<EOF | kubectl -n argocd apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $pod_name
+spec:
+  restartPolicy: Never
+  containers:
+    - name: argo-diff
+      command:
+        - /app/argo-diff
+      image: ghcr.io/vince-riv/argo-diff:${IMAGE_TAG}
+      env:
+        - name: ARGO_DIFF_COMMENT_PREAMBLE
+          value: |
+            ## Argo-Diff - Ephemeral Environment Test
+            This argo-diff should have the same output every run
+        - name: ARGO_DIFF_CONTEXT_STR
+          value: "${ARGO_DIFF_CONTEXT_STR}"
+        - name: ARGO_DIFF_SKIP_REF_CHECK
+          value: "true"
+        - name: ARGOCD_AUTH_TOKEN
+          value: dummy_value
+        - name: ARGOCD_SERVER_ADDR
+          value: argocd-server.argocd.svc.cluster.local:80
+        - name: ARGOCD_SERVER_INSECURE
+          value: "true"
+        - name: ARGOCD_SERVER_PLAINTEXT
+          value: "true"
+        - name: GITHUB_ACTIONS
+          value: "true"
+        - name: GITHUB_TOKEN
+          value: "${GITHUB_TOKEN}"
+        - name: GITHUB_SHA
+          value: "${GITHUB_SHA}"
+        - name: GITHUB_REF
+          value: "${PR_REF}"
+        - name: GITHUB_EVENT_NAME
+          value: "pull_request"
+        - name: GITHUB_HEAD_REF
+          value: "${GITHUB_HEAD_REF}"
+        - name: GITHUB_BASE_REF
+          value: "k3s-test"
+        - name: GITHUB_REPOSITORY
+          value: "${GITHUB_REPOSITORY}"
+        - name: REPO_DEFAULT_REF
+          value: "k3s-test"
+        - name: LOG_LEVEL
+          value: "debug"
+EOF
+
+echo "Waiting for pod $pod_name to reach a terminal phase..."
+phase=""
+for _ in $(seq 1 60); do
+  phase=$(kubectl -n argocd get pod "$pod_name" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  if [[ "$phase" == "Succeeded" || "$phase" == "Failed" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+echo "--- Pod logs ($pod_name) ---"
+kubectl -n argocd logs "$pod_name" || true
+
+if [[ "$phase" != "Succeeded" && "$phase" != "Failed" ]]; then
+  echo "::error::Pod $pod_name did not reach a terminal phase within timeout (last phase: $phase)"
+  exit 1
+fi
+
+exit_code=$(kubectl -n argocd get pod "$pod_name" -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}')
+echo "Pod $pod_name terminated with exit code $exit_code"
+
+case "$EXPECT_EXIT" in
+  0)
+    if [[ "$exit_code" != "0" ]]; then
+      echo "::error::Expected pod $pod_name to exit 0, but it exited $exit_code"
+      exit 1
+    fi
+    ;;
+  nonzero)
+    if [[ "$exit_code" == "0" ]]; then
+      echo "::error::Expected pod $pod_name to exit non-zero, but it exited 0"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "::error::Unknown EXPECT_EXIT value: $EXPECT_EXIT (expected '0' or 'nonzero')"
+    exit 1
+    ;;
+esac
+
+if [[ -n "${REQUIRE_LOG:-}" ]]; then
+  if ! kubectl -n argocd logs "$pod_name" | grep -qF -- "$REQUIRE_LOG"; then
+    echo "::error::Expected pod $pod_name logs to contain: $REQUIRE_LOG"
+    exit 1
+  fi
+fi
+
+echo "OK: pod $pod_name exited as expected (EXPECT_EXIT=$EXPECT_EXIT)"


### PR DESCRIPTION
## Summary

Follow-up to #240, whose test plan called for e2e coverage of the new
non-zero-exit-on-manifest-failure behavior. #240's unit test
(`TestDiffApplicationExitCodeHandling`) mocks `execArgoCdCli`, so it doesn't
prove the real `argocd app diff` produces the exit-1/empty-stdout condition,
or that argo-diff's real Actions-mode process then exits non-zero. This adds
that proof to `.github/workflows/k3s.yml`.

(#239 is pure ref-normalization logic already fully covered by unit tests —
`TestFilterApplicationsFullyQualifiedRefs`, `TestNormalizeBranchRef` — so it's
intentionally not given e2e coverage here.)

- Extracts the existing standalone-pod step into `test/run-argo-diff-pod.sh`,
  a reusable script that waits for the pod's terminal phase and asserts its
  exit code (`EXPECT_EXIT=0`/`nonzero`) plus an optional log substring
  (`REQUIRE_LOG`).
- Runs it twice:
  1. **Healthy** — same three existing apps, now asserting exit code 0 (a
     regression guard that #240 doesn't over-fail healthy apps).
  2. **Manifest failure** — after swapping the cluster to a single
     `broken-deployment` app (`test/argocd-broken-app.yaml`) whose source
     path doesn't exist at any revision, asserting a non-zero exit and that
     the logs show `Failed to diff application broken-deployment`.
- The swap step neutralizes `meta`'s finalizers before deleting it (it has
  `selfHeal`/`prune` and would otherwise resurrect the deleted healthy apps),
  then applies the broken app, which lives outside `test/argocd-applications/`
  so `meta` never manages or prunes it.

## Test plan

- [x] `go build -v ./...` / `go test ./...` (no Go changes, kept green)
- [x] `yq`/`yamllint`/`kubectl apply --dry-run=client` on the new YAML;
      `bash -n` on the new script
- [ ] Confirm on this PR that `.github/workflows/k3s.yml` runs and both new
      steps ("Run argo-diff (healthy)" exits 0, "Run argo-diff (manifest
      failure)" exits non-zero with the expected log line) go green
- [ ] Confirm two distinct argo-diff PR comments appear (healthy diffs vs. the
      single broken-app failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)