### PR TITLE
fix(gha): avoid overriding reserved env vars in k3s e2e runner

### DIFF
--- a/.github/workflows/k3s.yml
+++ b/.github/workflows/k3s.yml
@@ -163,9 +163,9 @@ jobs:
           POD_NAME_PREFIX: argo-diff-healthy
           IMAGE_TAG: ${{ steps.pr_info.outputs.IMAGE_TAG }}
           ARGO_DIFF_CONTEXT_STR: ephemeral-environment-test
-          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          GITHUB_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          ARGO_DIFF_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ARGO_DIFF_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
+          ARGO_DIFF_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_REF: ${{ steps.pr_info.outputs.PR_REF }}
           EXPECT_EXIT: "0"
@@ -192,9 +192,9 @@ jobs:
           POD_NAME_PREFIX: argo-diff-failure
           IMAGE_TAG: ${{ steps.pr_info.outputs.IMAGE_TAG }}
           ARGO_DIFF_CONTEXT_STR: ephemeral-environment-test-failure
-          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          GITHUB_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          ARGO_DIFF_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ARGO_DIFF_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
+          ARGO_DIFF_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_REF: ${{ steps.pr_info.outputs.PR_REF }}
           EXPECT_EXIT: nonzero

--- a/test/run-argo-diff-pod.sh
+++ b/test/run-argo-diff-pod.sh
@@ -6,12 +6,17 @@
 #   POD_NAME_PREFIX       - prefix for the pod name (a timestamp suffix is appended)
 #   IMAGE_TAG             - argo-diff image tag to run
 #   ARGO_DIFF_CONTEXT_STR - value for ARGO_DIFF_CONTEXT_STR (commit status / comment context)
-#   GITHUB_SHA            - commit sha argo-diff should diff against
-#   GITHUB_HEAD_REF       - PR head branch
-#   GITHUB_REPOSITORY     - owner/repo
+#   ARGO_DIFF_SHA         - commit sha argo-diff should diff against
+#   ARGO_DIFF_HEAD_REF    - PR head branch
+#   ARGO_DIFF_REPOSITORY  - owner/repo
 #   GITHUB_TOKEN          - GitHub token for commenting/status
 #   PR_REF                - GITHUB_REF value (e.g. refs/pull/N/merge)
 #   EXPECT_EXIT           - "0" to require success, "nonzero" to require failure
+#
+# Note: the ARGO_DIFF_SHA/HEAD_REF/REPOSITORY inputs are deliberately not named
+# GITHUB_SHA/GITHUB_HEAD_REF/GITHUB_REPOSITORY - those are GitHub Actions'
+# reserved default environment variables, and a step's own `env:` block cannot
+# override them (the runner silently keeps its own context value instead).
 #
 # Optional env vars:
 #   REQUIRE_LOG           - substring that must appear in the pod logs
@@ -19,7 +24,7 @@
 set -euo pipefail
 
 : "${POD_NAME_PREFIX:?}" "${IMAGE_TAG:?}" "${ARGO_DIFF_CONTEXT_STR:?}" \
-  "${GITHUB_SHA:?}" "${GITHUB_HEAD_REF:?}" "${GITHUB_REPOSITORY:?}" \
+  "${ARGO_DIFF_SHA:?}" "${ARGO_DIFF_HEAD_REF:?}" "${ARGO_DIFF_REPOSITORY:?}" \
   "${GITHUB_TOKEN:?}" "${PR_REF:?}" "${EXPECT_EXIT:?}"
 
 pod_name="${POD_NAME_PREFIX}-$(date +%s)"
@@ -58,17 +63,17 @@ spec:
         - name: GITHUB_TOKEN
           value: "${GITHUB_TOKEN}"
         - name: GITHUB_SHA
-          value: "${GITHUB_SHA}"
+          value: "${ARGO_DIFF_SHA}"
         - name: GITHUB_REF
           value: "${PR_REF}"
         - name: GITHUB_EVENT_NAME
           value: "pull_request"
         - name: GITHUB_HEAD_REF
-          value: "${GITHUB_HEAD_REF}"
+          value: "${ARGO_DIFF_HEAD_REF}"
         - name: GITHUB_BASE_REF
           value: "k3s-test"
         - name: GITHUB_REPOSITORY
-          value: "${GITHUB_REPOSITORY}"
+          value: "${ARGO_DIFF_REPOSITORY}"
         - name: REPO_DEFAULT_REF
           value: "k3s-test"
         - name: LOG_LEVEL


### PR DESCRIPTION
## Summary

While testing the merged #241 changes with a dummy commit under a
`workflow_run` trigger (not a live PR), the k3s e2e job crashed:
`test/run-argo-diff-pod.sh: line 21: GITHUB_HEAD_REF: parameter null or not set`
(https://github.com/vince-riv/argo-diff/actions/runs/28751913068/job/85252413281).

Root cause: `GITHUB_SHA`, `GITHUB_HEAD_REF`, and `GITHUB_REPOSITORY` are
GitHub Actions' own reserved default environment variables. A workflow
step's `env:` block cannot override them — the runner silently keeps its
own context value instead. `.github/workflows/k3s.yml` was declaring these
at the step level so `run-argo-diff-pod.sh` could read them, which worked
by coincidence on #241's PR-triggered test run (the defaults happened to
equal what was being passed in), but breaks on `workflow_run`-triggered
runs: `GITHUB_HEAD_REF` defaults to empty there (only populated for
`pull_request`/`pull_request_target` events), which is what crashed this
run. Worse, had the required-var check not caught it, `GITHUB_SHA` would
have silently defaulted to the default branch's head sha instead of the
PR's — a silent wrong-revision bug, not just a crash.

## Fix

Rename the script's three colliding inputs to `ARGO_DIFF_SHA`,
`ARGO_DIFF_HEAD_REF`, `ARGO_DIFF_REPOSITORY` (non-reserved names), while
the pod's own container env (a separate process) keeps using the real
`GITHUB_SHA`/`GITHUB_HEAD_REF`/`GITHUB_REPOSITORY` names that argo-diff
itself expects.

## Test plan

- [x] `bash -n test/run-argo-diff-pod.sh`
- [ ] Confirm the k3s workflow goes green on this PR (a real `pull_request`
      trigger) and, more importantly, re-run the dummy-commit scenario that
      originally failed to confirm the `workflow_run` path now works too

🤖 Generated with [Claude Code](https://claude.com/claude-code)