### PR TITLE
fix: clarify nested Argo Application diff log message

### DIFF
--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -157,7 +157,7 @@ func GetApplicationChanges(ctx context.Context, eventInfo webhook.EventInfo) ([]
 				log.Warn().Err(err).Msgf("Unable to determine if argo app %s has other argo apps with changes", app.ObjectMeta.Name)
 			} else {
 				// diff matching multi-source application
-				log.Info().Msgf("%d Argo applications detected to have changes via %s", len(appsWithChanges), app.ObjectMeta.Name)
+				log.Info().Msgf("Found %d nested ArgoCD Application(s) with changes within '%s'", len(appsWithChanges), app.Name)
 				for _, subApp := range appsWithChanges {
 					if subAppCur, ok := appLookup[subApp.ObjectMeta.Name]; ok {
 						multiSrcAppNamesDiffed = append(multiSrcAppNamesDiffed, subApp.ObjectMeta.Name)


### PR DESCRIPTION
## Summary
- The log line reporting nested/child ArgoCD Application resources found within an app's diff (the app-of-apps case) was worded like a top-level "changes detected" summary, e.g. `"0 Argo applications detected to have changes via argocd"`.
- This was misread as meaning the app itself had no changes, even though the surrounding code only reaches this log line after confirming the app *does* have diffed changes.
- Reworded to `"Found %d nested ArgoCD Application(s) with changes within '%s'"` so it can't be confused with a no-changes result.

## Test plan
- [x] `go build -v ./...`
- [ ] Verify updated log line renders correctly in a real GitHub Actions run against an app with/without nested Application manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)