### PR TITLE
fix: compute true previous stable tag for GoReleaser changelogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,14 @@ jobs:
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Determine previous stable release
+        id: prevstable
+        if: ${{ steps.relmeta.outputs.prerelease == 'false' }}
+        run: |
+          VERSION="${{ steps.relmeta.outputs.version }}"
+          STABLE_TAGS="$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -vFx "${VERSION}" || true)"
+          PREV_STABLE="$(printf '%s\n%s\n' "${STABLE_TAGS}" "${VERSION}" | sort -V | grep -B1 -Fx "${VERSION}" | head -1)"
+          echo "previous_stable=${PREV_STABLE}" >> "$GITHUB_OUTPUT"
       - name: Verify action.yml image matches release version
         run: |
           VERSION="${{ steps.relmeta.outputs.version }}"
@@ -63,6 +71,9 @@ jobs:
           # This repo stacks chart-*/actions-*/plain-semver tags on the same commit;
           # pin the exact tag so GoReleaser doesn't guess the wrong one.
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.ref || github.ref_name }}
+          # Empty on prereleases (step above is skipped) - GoReleaser falls back to
+          # its default git-describe lookup, which is fine for rc-to-rc changelogs.
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prevstable.outputs.previous_stable }}
       - name: Remap binaries for Docker build
         run: |
           mkdir -p temp


### PR DESCRIPTION
## Summary
- GoReleaser OSS picks the "previous tag" via `git describe` (commit-graph reachability), not semver, and doesn't skip prereleases (that's a Pro-only feature).
- Since `scripts/prep-release.sh` tags a fresh commit per release, cutting a stable release after one or more RCs would resolve GoReleaser's previous tag to the last RC instead of the last stable release, truncating the changelog to just the prep commit.
- Adds a `Determine previous stable release` step (gated on `prerelease == 'false'`) that computes the true previous bare `X.Y.Z` tag and feeds it into `GORELEASER_PREVIOUS_TAG`, leaving prereleases on GoReleaser's default behavior (RC-to-RC diffs).

## Test plan
- [x] `actionlint` on the updated `release.yml` (clean)
- [x] Verified the shell logic against this repo's real tag graph: `2.10.1` resolves to `2.10.0`
- [ ] On the next stable release, confirm the step logs `previous_stable=2.10.0` and the GitHub Release changelog spans `2.10.0` → `2.10.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)