### PR TITLE
feat(gha): create GitHub Releases from chart-releaser

### DIFF
--- a/.github/cliff-chart.toml
+++ b/.github/cliff-chart.toml
@@ -1,0 +1,31 @@
+# git-cliff config for chart-scoped release notes (see .github/workflows/chart-releaser.yml).
+# Header/footer are stripped via --strip all at invocation time; keep them empty here too.
+
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }} ({{ commit.id | truncate(length=7, end="") }})
+{% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+filter_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^docs", skip = true },
+  { message = "^test", skip = true },
+  { message = "^chore", group = "Other" },
+  { message = ".*", group = "Other" },
+]

--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -5,7 +5,7 @@ on:
   push:
     tags:
       - 'chart-[0-9]+.[0-9]+.[0-9]+'
-      - 'chart-[0-9]+.[0-9]+.[0-9]+-*'
+      - 'chart-[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
   workflow_dispatch:
     inputs:
       ref:
@@ -14,29 +14,27 @@ on:
 env:
   GCR: ghcr.io/${{ github.repository_owner }}
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   publish-chart:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
-      #- name: Install Helm
-      #  uses: azure/setup-helm@v3
-      #  with:
-      #    version: 3.13.2
-      #    token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: 'true'
       - name: Install yq
         run: sudo snap install yq
       - name: Extract Chart Version
         id: extract_version
         run: |
-          VERSION=$(yq e '.version' charts/argo-diff/Chart.yaml)
-          echo "chart_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "chart_version=$(yq e '.version' charts/argo-diff/Chart.yaml)" >> "$GITHUB_OUTPUT"
+          echo "app_version=$(yq e '.appVersion' charts/argo-diff/Chart.yaml)" >> "$GITHUB_OUTPUT"
       - name: Verify Chart Version
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
@@ -45,17 +43,62 @@ jobs:
             echo "Tag version ($TAG_VERSION) does not match the chart version (${{ steps.extract_version.outputs.chart_version }})"
             exit 1
           fi
+      - name: Release metadata
+        id: relmeta
+        run: |
+          TAG="${{ github.event.inputs.ref || github.ref_name }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [[ "${TAG}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Determine previous chart release
+        id: prevchart
+        run: |
+          TAG="${{ steps.relmeta.outputs.tag }}"
+          CHART_TAGS="$(git tag -l 'chart-*' | grep -vFx "${TAG}" || true)"
+          PREV_CHART="$(printf '%s\n%s\n' "${CHART_TAGS}" "${TAG}" | sort -V | grep -B1 -Fx "${TAG}" | head -1)"
+          echo "prev_tag=${PREV_CHART}" >> "$GITHUB_OUTPUT"
       - name: Helm login
         run: |
           helm version
-          cd charts/argo-diff
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ${{ env.GCR }} --username ${{ github.repository_owner }} --password-stdin
+      - name: Package chart
+        run: helm package charts/argo-diff --destination dist
       - name: Helm push
-        run: |
-          set -x
-          cd charts/argo-diff
-          version=${{ steps.extract_version.outputs.chart_version }}
-          helm package .
-          helm push ./argo-diff-$version.tgz oci://${{ env.GCR }}/chart
+        run: helm push dist/argo-diff-${{ steps.extract_version.outputs.chart_version }}.tgz oci://${{ env.GCR }}/chart
       - name: Helm logout
         run: helm registry logout ${{ env.GCR }}
+      - name: Generate chart changelog
+        id: changelog
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
+        with:
+          config: .github/cliff-chart.toml
+          args: >-
+            --include-path 'charts/argo-diff/**'
+            --strip all
+            ${{ steps.prevchart.outputs.prev_tag && format('{0}..{1}', steps.prevchart.outputs.prev_tag, steps.relmeta.outputs.tag) || '--current' }}
+        env:
+          OUTPUT: dist/CHANGELOG.md
+      - name: Build release notes
+        run: |
+          APP="${{ steps.extract_version.outputs.app_version }}"
+          {
+            echo "Ships argo-diff **${APP}** by default — see the [\`${APP}\` app release](${{ github.server_url }}/${{ github.repository }}/releases/tag/${APP})."
+            echo
+            echo "## Chart changes"
+            echo
+            cat dist/CHANGELOG.md
+          } > dist/RELEASE_NOTES.md
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.relmeta.outputs.tag }}" \
+            dist/argo-diff-${{ steps.extract_version.outputs.chart_version }}.tgz \
+            --title "Chart ${{ steps.extract_version.outputs.chart_version }}" \
+            --notes-file dist/RELEASE_NOTES.md \
+            --verify-tag \
+            --latest=false \
+            ${{ steps.relmeta.outputs.prerelease == 'true' && '--prerelease' || '' }}

--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -59,7 +59,12 @@ jobs:
           TAG="${{ steps.relmeta.outputs.tag }}"
           CHART_TAGS="$(git tag -l 'chart-*' | grep -vFx "${TAG}" || true)"
           PREV_CHART="$(printf '%s\n%s\n' "${CHART_TAGS}" "${TAG}" | sort -V | grep -B1 -Fx "${TAG}" | head -1)"
-          echo "prev_tag=${PREV_CHART}" >> "$GITHUB_OUTPUT"
+          # No earlier chart-* tag (e.g. very first chart release): fall back to the
+          # repo root so the changelog range still resolves.
+          if [ -z "${PREV_CHART}" ]; then
+            PREV_CHART="$(git rev-list --max-parents=0 HEAD | tail -1)"
+          fi
+          echo "range_start=${PREV_CHART}" >> "$GITHUB_OUTPUT"
       - name: Helm login
         run: |
           helm version
@@ -75,10 +80,14 @@ jobs:
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: .github/cliff-chart.toml
+          # tag-pattern scopes tag resolution to chart-* — this repo stacks chart-*,
+          # actions-*, and plain-semver tags on the same commits, and without it
+          # git-cliff splits the range into one section per tag scheme instead of one.
           args: >-
             --include-path 'charts/argo-diff/**'
+            --tag-pattern '^chart-'
             --strip all
-            ${{ steps.prevchart.outputs.prev_tag && format('{0}..{1}', steps.prevchart.outputs.prev_tag, steps.relmeta.outputs.tag) || '--current' }}
+            ${{ format('{0}..{1}', steps.prevchart.outputs.range_start, steps.relmeta.outputs.tag) }}
         env:
           OUTPUT: dist/CHANGELOG.md
       - name: Build release notes
@@ -97,7 +106,7 @@ jobs:
         run: |
           gh release create "${{ steps.relmeta.outputs.tag }}" \
             dist/argo-diff-${{ steps.extract_version.outputs.chart_version }}.tgz \
-            --title "Chart ${{ steps.extract_version.outputs.chart_version }}" \
+            --title "${{ steps.relmeta.outputs.tag }}" \
             --notes-file dist/RELEASE_NOTES.md \
             --verify-tag \
             --latest=false \


### PR DESCRIPTION
## Summary
- Adds GitHub Release creation to the chart-releaser workflow alongside the existing GHCR push, for `chart-X.Y.Z` and `chart-X.Y.Z-rcN` tags
- Each release attaches the packaged chart `.tgz`, is never marked "latest", is marked prerelease for `-rc#` tags, and includes a chart-scoped changelog (via new `.github/cliff-chart.toml` git-cliff config) plus a link to the matching `argo-diff` app release
- Release title matches the tag (`chart-X.Y.Z`), consistent with existing chart releases

## Test plan
- [x] `actionlint` / `yamllint` clean on the workflow
- [x] Local `git-cliff` dry-run against real tag history for both the `prev..tag` range and first-release fallback
- [x] End-to-end: pushed `chart-2.10.1-rc2` test tag — release created as prerelease, not latest, title `chart-2.10.1-rc2`, `.tgz` asset attached, single deduped changelog section, working link to the `2.10.1` app release, GHCR push still succeeds
- [ ] End-to-end test of a stable (non-rc) tag to confirm non-prerelease behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)