### PR TITLE
fix(gha): fix false-positive prerelease detection on stable chart tags

### DIFF
--- a/.github/workflows/chart-releaser.yml
+++ b/.github/workflows/chart-releaser.yml
@@ -48,7 +48,10 @@ jobs:
         run: |
           TAG="${{ github.event.inputs.ref || github.ref_name }}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          if [[ "${TAG}" == *-* ]]; then
+          # Strip the "chart-" prefix before checking for a prerelease suffix - the
+          # prefix itself contains a hyphen, so checking the raw tag always matches.
+          CHART_VERSION="${TAG#chart-}"
+          if [[ "${CHART_VERSION}" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The `chart-2.10.1` stable test tag (from #257) was released as a prerelease. The hyphen check ran against the raw tag (`chart-2.10.1`), and the `chart-` prefix itself contains a hyphen, so every stable chart release matched `*-*` and was marked prerelease.
- Strip the `chart-` prefix before checking for an `-rc` suffix.
- Manually corrected the already-published `chart-2.10.1` release (`prerelease: false` now, verified via `gh release view`).

## Test plan
- [x] `actionlint` clean
- [x] Verified `chart-2.10.1` release now shows `prerelease: false`
- [ ] Push another stable `chart-*` tag to confirm the workflow itself now sets `prerelease=false` (previous verification was a manual correction, not a workflow re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)