### PR TITLE
fix(action): add required marketplace metadata, fix input typo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 ---
 
+name: 'argo-diff'
 description: 'Preview k8s manifest changes using argocd diff'
+author: 'vince-riv'
+branding:
+  icon: 'git-pull-request'
+  color: 'blue'
 inputs:
   argocd_auth_token:
     description: 'Bearer token for ArgoCD (value passed to --auth-token)'
@@ -60,7 +65,7 @@ inputs:
     required: false
     default: info
   repo_default_ref:
-    decription: 'Default branch of repository (eg: "main"); only needed when `HEAD` is specified as target revision in ArgoCD application source'
+    description: 'Default branch of repository (eg: "main"); only needed when `HEAD` is specified as target revision in ArgoCD application source'
     required: false
     default: ''
 


### PR DESCRIPTION
## Summary
- Adds `name`, `author`, and `branding` to `action.yml` — `name` is required by the metadata schema and is what the Marketplace uses as the listing title; the action wasn't publishable without it.
- Fixes a `decription` → `description` typo on the `repo_default_ref` input, which was silently dropping that input's description.

## Test plan
- [x] Confirm `ghcr.io/vince-riv/argo-diff` package visibility is Public (required for consumers to pull the image with no auth)
- [x] Verify `argo-diff` doesn't collide with an existing name when publishing via the GitHub UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)