### PR TITLE
feat: match ArgoCD apps on non-github.com git hosts

### DIFF
--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -261,6 +261,25 @@ func gitRepoMatch(repoUrl, repoOwner, repoName string) bool {
 			return true
 		}
 	}
+	// Fallback for non-github.com hosts (GitHub Enterprise, AWS CodeConnections,
+	// mirrors, etc.): match the owner/repo path suffix regardless of host. The
+	// leading separator ('/' for HTTP(S) paths, ':' for scp-style SSH) anchors
+	// the owner boundary so a URL ending in "…/otherowner/repo" is not matched
+	// for owner "owner". Comparison is case-insensitive since git hosting
+	// providers treat owner and repo names case-insensitively.
+	repoUrlLower := strings.ToLower(repoUrl)
+	for _, sep := range []string{"/", ":"} {
+		fallbacks := []string{
+			fmt.Sprintf("%s%s/%s.git", sep, repoOwner, repoName),
+			fmt.Sprintf("%s%s/%s", sep, repoOwner, repoName),
+		}
+		for _, fallback := range fallbacks {
+			if strings.HasSuffix(repoUrlLower, strings.ToLower(fallback)) {
+				log.Debug().Msgf("gitRepoMatch() - non-github host suffix match: %q ends with %q", repoUrl, fallback)
+				return true
+			}
+		}
+	}
 	return false
 }
 

--- a/internal/argocd/helper_test.go
+++ b/internal/argocd/helper_test.go
@@ -275,3 +275,36 @@ func TestManifestIsArgoApplication(t *testing.T) {
 		}
 	}
 }
+
+func TestGitRepoMatch(t *testing.T) {
+	const owner = "acme"
+	const repo = "widgets"
+	tests := []struct {
+		name    string
+		repoURL string
+		want    bool
+	}{
+		// github.com (existing behavior)
+		{"github https .git", "https://github.com/acme/widgets.git", true},
+		{"github https no .git", "https://github.com/acme/widgets", true},
+		{"github scp ssh", "git@github.com:acme/widgets.git", true},
+		// non-github hosts (new fallback)
+		{"github enterprise", "https://github.example.com/acme/widgets.git", true},
+		{"aws codeconnections", "https://codeconnections.us-west-2.amazonaws.com/git-http/111122223333/us-west-2/1a2b3c/acme/widgets.git", true},
+		{"gitlab mirror no .git", "https://gitlab.example.com/group/acme/widgets", true},
+		{"generic scp ssh", "git@git.example.com:acme/widgets.git", true},
+		{"case insensitive", "https://github.example.com/ACME/Widgets.git", true},
+		// negatives
+		{"different repo", "https://github.example.com/acme/gadgets.git", false},
+		{"owner suffix must not partial match", "https://github.example.com/notacme/widgets.git", false},
+		{"repo name substring", "https://github.example.com/acme/widgets-internal.git", false},
+		{"empty url", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gitRepoMatch(tc.repoURL, owner, repo); got != tc.want {
+				t.Errorf("gitRepoMatch(%q, %q, %q) = %v; want %v", tc.repoURL, owner, repo, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Related to #160 (non-github.com host support — see scope note below).

`gitRepoMatch()` only recognizes `github.com` URLs (it builds `host/owner/repo` candidates in HTTP(S) and scp-style SSH forms). Applications whose source `repoURL` points at a **non-github.com host** are therefore never matched, and argo-diff produces no diff for them.

This affects, at least:
- **GitHub Enterprise Server** (`github.example.com/owner/repo.git`)
- **AWS CodeConnections** (`https://codeconnections.<region>.amazonaws.com/git-http/<account>/<region>/<uuid>/owner/repo.git`) — ArgoCD can consume these directly, and this is what surfaced the gap for us
- **GitLab / self-hosted GitLab** and other providers that preserve the `owner/repo` path
- read-only mirrors

## Change

Add a host-agnostic fallback that runs **only after** the existing github.com candidates fail to match, so current behavior is unchanged. The fallback matches the `owner/repo` path suffix (`.git` optional):

- The leading separator (`/` for HTTP(S) paths, `:` for scp-style SSH) anchors the owner boundary, so a URL ending in `…/otherowner/repo` is **not** matched for owner `owner`.
- Comparison is case-insensitive, since git hosting providers treat owner/repo names case-insensitively.

## Tests

Adds `TestGitRepoMatch` (table-driven) covering:
- github.com https (with/without `.git`) and scp-style SSH — existing behavior
- GitHub Enterprise, AWS CodeConnections, mirror without `.git`, generic scp SSH — new behavior
- case-insensitive match
- negatives: different repo, partial owner match (`notacme/widgets`), repo-name substring (`widgets-internal`), empty URL

`go test ./internal/argocd/`, `go vet`, and `gofmt` all pass locally.

## Scope note re #160

This PR only makes **application/repo matching** work for non-github.com hosts. It does **not** add the GitLab API client, webhook, or runner support that #160 tracks — comment delivery still uses the GitHub API. It's a prerequisite/building block, not a full resolution of #160.

## Notes / alternatives considered

- Kept the change purely additive rather than replacing the github.com-specific candidates, to minimize behavioral risk for existing users.
- Happy to gate this behind an env var / config flag instead if you'd prefer it be opt-in — let me know.