### PR TITLE
feat: match ArgoCD apps on non-github.com git hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ the accepted environment variables and their respective GitHub Actions inputs.
 | ARGOCD_UI_BASE_URL               | argocd_ui_base_url          | no               |          | Base URL of ArgoCD UI (usually the server name prefixed with `https://`). |
 | ARGO_DIFF_COMMENT_PREAMBLE       | comment_preamble            | no               |          | String/markdown prefixed to comments. Keep to 150 chars or less. |
 | ARGO_DIFF_CONTEXT_STR            | context_str                 | no               |          | Unique identifier of the argo-diff instance. Use when deploying multiple instances (eg: one per cluster); a brief cluster nickname is recommended. |
+| ARGO_DIFF_DISABLE_NON_GITHUB_REPO_MATCH | N/A                   | no               | `false`  | Set to `true` to disable matching ArgoCD application sources on non-`github.com` git hosts (GitHub Enterprise, AWS CodeConnections, GitLab, mirrors, etc.) by `owner/repo` path suffix; matching on `github.com` URLs is unaffected. |
 | COMMENT_LINE_MAX_CHARS           | comment_line_max_chars      | no               | `175`    | Individual lines in argo-diff PR comments longer than this are truncated. |
 | GITHUB_APP_ID                    | N/A                         | no               |          | GitHub Application Id (see deployment instructions). |
 | GITHUB_APP_INSTALLATION_ID       | N/A                         | no               |          | GitHub Application Installation Id (see deployment instructions). |

--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -100,7 +100,7 @@ func getMultiSrcAppChanges(ctx context.Context, appCur *Application, appNew *App
 		if curSrc.RepoURL != newSources[i].RepoURL {
 			return appResChanges, fmt.Errorf("source URL is changing in %s", appName)
 		}
-		if gitRepoMatch(curSrc.RepoURL, repoOwner, repoName) {
+		if gitRepoMatch(curSrc, repoOwner, repoName) {
 			newRevision = revision
 		}
 		revisions = append(revisions, newRevision)
@@ -198,7 +198,7 @@ func GetApplicationChanges(ctx context.Context, eventInfo webhook.EventInfo) ([]
 		revList := []string{}
 		srcPos := []int{}
 		for i, appSrc := range app.Spec.GetSources() {
-			if gitRepoMatch(appSrc.RepoURL, eventInfo.RepoOwner, eventInfo.RepoName) {
+			if gitRepoMatch(appSrc, eventInfo.RepoOwner, eventInfo.RepoName) {
 				revList = append(revList, eventInfo.Sha)
 				srcPos = append(srcPos, i+1)
 			}
@@ -247,7 +247,16 @@ func filterApplications(a []Application, eventInfo webhook.EventInfo, multiSourc
 	return appList, nil
 }
 
-func gitRepoMatch(repoUrl, repoOwner, repoName string) bool {
+func gitRepoMatch(appSrc ApplicationSource, repoOwner, repoName string) bool {
+	if appSrc.Chart != "" {
+		// Chart/OCI registry sources aren't git remotes, so RepoURL isn't a git
+		// remote URL here (e.g. "oci://registry.example.com/acme/widgets" for a
+		// Helm chart). Never treat them as matching a changed git repo, since
+		// the host-agnostic fallback below would otherwise be prone to
+		// coincidental owner/repo path collisions with unrelated charts.
+		return false
+	}
+	repoUrl := appSrc.RepoURL
 	const githubHost = "github.com"
 	candidates := []string{
 		fmt.Sprintf("%s/%s/%s.git", githubHost, repoOwner, repoName),
@@ -260,6 +269,10 @@ func gitRepoMatch(repoUrl, repoOwner, repoName string) bool {
 		if strings.HasSuffix(repoUrl, candidate) {
 			return true
 		}
+	}
+	if strings.ToLower(os.Getenv("ARGO_DIFF_DISABLE_NON_GITHUB_REPO_MATCH")) == "true" {
+		log.Debug().Msg("gitRepoMatch() - non-github host fallback disabled via ARGO_DIFF_DISABLE_NON_GITHUB_REPO_MATCH")
+		return false
 	}
 	// Fallback for non-github.com hosts (GitHub Enterprise, AWS CodeConnections,
 	// mirrors, etc.): match the owner/repo path suffix regardless of host. The
@@ -301,7 +314,7 @@ func checkSource(appSpecSource ApplicationSource, appName string, eventInfo webh
 	log.Trace().Msgf("checkSource() - appname: %s (autosync %t)", appName, automatedSync)
 	log.Trace().Msgf("checkSource() - appSpecSource: %+v", appSpecSource)
 	log.Trace().Msgf("checkSource() - eventInfo: %+v", eventInfo)
-	if !gitRepoMatch(appSpecSource.RepoURL, eventInfo.RepoOwner, eventInfo.RepoName) {
+	if !gitRepoMatch(appSpecSource, eventInfo.RepoOwner, eventInfo.RepoName) {
 		log.Debug().Msgf("Filtering application %s: RepoURL %s doesn't mach owner/repo %s/%s", appName, appSpecSource.RepoURL, eventInfo.RepoOwner, eventInfo.RepoName)
 		return false
 	}

--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -261,6 +261,25 @@ func gitRepoMatch(repoUrl, repoOwner, repoName string) bool {
 			return true
 		}
 	}
+	// Fallback for non-github.com hosts (GitHub Enterprise, AWS CodeConnections,
+	// mirrors, etc.): match the owner/repo path suffix regardless of host. The
+	// leading separator ('/' for HTTP(S) paths, ':' for scp-style SSH) anchors
+	// the owner boundary so a URL ending in "…/otherowner/repo" is not matched
+	// for owner "owner". Comparison is case-insensitive since git hosting
+	// providers treat owner and repo names case-insensitively.
+	repoUrlLower := strings.ToLower(repoUrl)
+	for _, sep := range []string{"/", ":"} {
+		fallbacks := []string{
+			fmt.Sprintf("%s%s/%s.git", sep, repoOwner, repoName),
+			fmt.Sprintf("%s%s/%s", sep, repoOwner, repoName),
+		}
+		for _, fallback := range fallbacks {
+			if strings.HasSuffix(repoUrlLower, strings.ToLower(fallback)) {
+				log.Debug().Msgf("gitRepoMatch() - non-github host suffix match: %q ends with %q", repoUrl, fallback)
+				return true
+			}
+		}
+	}
 	return false
 }
 

--- a/internal/argocd/helper_test.go
+++ b/internal/argocd/helper_test.go
@@ -282,28 +282,63 @@ func TestGitRepoMatch(t *testing.T) {
 	tests := []struct {
 		name    string
 		repoURL string
+		chart   string
 		want    bool
 	}{
 		// github.com (existing behavior)
-		{"github https .git", "https://github.com/acme/widgets.git", true},
-		{"github https no .git", "https://github.com/acme/widgets", true},
-		{"github scp ssh", "git@github.com:acme/widgets.git", true},
+		{"github https .git", "https://github.com/acme/widgets.git", "", true},
+		{"github https no .git", "https://github.com/acme/widgets", "", true},
+		{"github scp ssh", "git@github.com:acme/widgets.git", "", true},
 		// non-github hosts (new fallback)
-		{"github enterprise", "https://github.example.com/acme/widgets.git", true},
-		{"aws codeconnections", "https://codeconnections.us-west-2.amazonaws.com/git-http/111122223333/us-west-2/1a2b3c/acme/widgets.git", true},
-		{"gitlab mirror no .git", "https://gitlab.example.com/group/acme/widgets", true},
-		{"generic scp ssh", "git@git.example.com:acme/widgets.git", true},
-		{"case insensitive", "https://github.example.com/ACME/Widgets.git", true},
+		{"github enterprise", "https://github.example.com/acme/widgets.git", "", true},
+		{"aws codeconnections", "https://codeconnections.us-west-2.amazonaws.com/git-http/111122223333/us-west-2/1a2b3c/acme/widgets.git", "", true},
+		{"gitlab mirror no .git", "https://gitlab.example.com/group/acme/widgets", "", true},
+		{"generic scp ssh", "git@git.example.com:acme/widgets.git", "", true},
+		{"case insensitive", "https://github.example.com/ACME/Widgets.git", "", true},
 		// negatives
-		{"different repo", "https://github.example.com/acme/gadgets.git", false},
-		{"owner suffix must not partial match", "https://github.example.com/notacme/widgets.git", false},
-		{"repo name substring", "https://github.example.com/acme/widgets-internal.git", false},
-		{"empty url", "", false},
+		{"different repo", "https://github.example.com/acme/gadgets.git", "", false},
+		{"owner suffix must not partial match", "https://github.example.com/notacme/widgets.git", "", false},
+		{"repo name substring", "https://github.example.com/acme/widgets-internal.git", "", false},
+		{"empty url", "", "", false},
+		// Chart/OCI sources must never match, even if RepoURL's path happens to
+		// collide with owner/repo (RepoURL here is a Helm/OCI registry, not a
+		// git remote).
+		{"chart source with colliding path is never matched", "oci://registry.example.com/acme/widgets", "widgets", false},
+		{"chart source with github.com host is never matched", "https://github.com/acme/widgets.git", "widgets", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := gitRepoMatch(tc.repoURL, owner, repo); got != tc.want {
-				t.Errorf("gitRepoMatch(%q, %q, %q) = %v; want %v", tc.repoURL, owner, repo, got, tc.want)
+			src := ApplicationSource{RepoURL: tc.repoURL, Chart: tc.chart}
+			if got := gitRepoMatch(src, owner, repo); got != tc.want {
+				t.Errorf("gitRepoMatch(%+v, %q, %q) = %v; want %v", src, owner, repo, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitRepoMatch_DisableNonGithubFallback(t *testing.T) {
+	const owner = "acme"
+	const repo = "widgets"
+	tests := []struct {
+		name     string
+		repoURL  string
+		disabled string
+		want     bool
+	}{
+		{"non-github host matches when flag unset", "https://github.example.com/acme/widgets.git", "", true},
+		{"non-github host matches when flag false", "https://github.example.com/acme/widgets.git", "false", true},
+		{"non-github host blocked when flag true", "https://github.example.com/acme/widgets.git", "true", false},
+		{"non-github host blocked when flag TRUE (case-insensitive)", "https://github.example.com/acme/widgets.git", "TRUE", false},
+		{"github.com still matches when flag true", "https://github.com/acme/widgets.git", "true", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Empty string behaves identically to the var being unset, since the
+			// check only looks for the literal value "true".
+			t.Setenv("ARGO_DIFF_DISABLE_NON_GITHUB_REPO_MATCH", tc.disabled)
+			src := ApplicationSource{RepoURL: tc.repoURL}
+			if got := gitRepoMatch(src, owner, repo); got != tc.want {
+				t.Errorf("gitRepoMatch(%+v, %q, %q) with ARGO_DIFF_DISABLE_NON_GITHUB_REPO_MATCH=%q = %v; want %v", src, owner, repo, tc.disabled, got, tc.want)
 			}
 		})
 	}

--- a/internal/argocd/helper_test.go
+++ b/internal/argocd/helper_test.go
@@ -275,3 +275,36 @@ func TestManifestIsArgoApplication(t *testing.T) {
 		}
 	}
 }
+
+func TestGitRepoMatch(t *testing.T) {
+	const owner = "acme"
+	const repo = "widgets"
+	tests := []struct {
+		name    string
+		repoURL string
+		want    bool
+	}{
+		// github.com (existing behavior)
+		{"github https .git", "https://github.com/acme/widgets.git", true},
+		{"github https no .git", "https://github.com/acme/widgets", true},
+		{"github scp ssh", "git@github.com:acme/widgets.git", true},
+		// non-github hosts (new fallback)
+		{"github enterprise", "https://github.example.com/acme/widgets.git", true},
+		{"aws codeconnections", "https://codeconnections.us-west-2.amazonaws.com/git-http/111122223333/us-west-2/1a2b3c/acme/widgets.git", true},
+		{"gitlab mirror no .git", "https://gitlab.example.com/group/acme/widgets", true},
+		{"generic scp ssh", "git@git.example.com:acme/widgets.git", true},
+		{"case insensitive", "https://github.example.com/ACME/Widgets.git", true},
+		// negatives
+		{"different repo", "https://github.example.com/acme/gadgets.git", false},
+		{"owner suffix must not partial match", "https://github.example.com/notacme/widgets.git", false},
+		{"repo name substring", "https://github.example.com/acme/widgets-internal.git", false},
+		{"empty url", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gitRepoMatch(tc.repoURL, owner, repo); got != tc.want {
+				t.Errorf("gitRepoMatch(%q, %q, %q) = %v; want %v", tc.repoURL, owner, repo, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Builds on #266 (by @nakul-detroja — thanks for the original fix and test coverage!), which added a host-agnostic fallback to `gitRepoMatch()` so ArgoCD application sources on non-`github.com` git hosts (GitHub Enterprise, AWS CodeConnections, GitLab, mirrors, etc.) can be matched by `owner/repo` path suffix.

Since that fallback is host-agnostic, it's also source-type-agnostic: `gitRepoMatch()` is called on every source's `RepoURL` in multi-source apps regardless of whether the source is a git repo or a Helm/OCI chart. A chart source's `RepoURL` (e.g. `oci://registry.example.com/acme/widgets`) isn't a git remote, but could coincidentally match the same `owner/repo` suffix as the git source it's paired with — causing the wrong source to receive the revision substitution, or be incorrectly included in a multi-source diff.

## Changes

- `gitRepoMatch()` now takes the full `ApplicationSource` and returns `false` immediately when `Chart != ""`, since chart/OCI sources are never git remotes.
- Adds `ARGO_DIFF_DISABLE_NON_GITHUB_REPO_MATCH` (default `false`) as an opt-out escape hatch for the non-`github.com` fallback specifically; matching on `github.com` URLs is unaffected by the flag.
- Updates the three call sites (`getMultiSrcAppChanges`, `GetApplicationChanges`, `checkSource`) to pass the `ApplicationSource` instead of just `.RepoURL`.
- Adds test coverage for the chart guard and the new env var (unset/false/true/case-insensitive, plus confirming `github.com` matching is unaffected).
- Documents the new env var in README.md's Configuration table.

## Test plan

- [x] `go build -v ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./...` (full suite passes)