### PR TITLE
feat(chart): add chart support for pinning the argocd CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ configuration.
   ```console
   helm install my-release oci://ghcr.io/vince-riv/chart/argo-diff
   ```
+  To run an argocd CLI version other than the one baked into the argo-diff image, set the chart's
+  `argocdCli.image.tag` value — see [charts/argo-diff/README.md](charts/argo-diff/README.md#values).
 - Alternatively, use the example manifests in [docs/k8s/](docs/k8s/) to deploy argo-diff to the argocd
   namespace of your cluster. You'll need to add an Ingress or IngressRoute so GitHub can reach the
   `/webhook` endpoint on the argo-diff Service.
@@ -215,7 +217,7 @@ the accepted environment variables and their respective GitHub Actions inputs.
 | APP_ENV                          | N/A                         | no               |          | Set to `dev` during local development. |
 | ARGOCD_AUTH_TOKEN                | argocd_auth_token           | yes              |          | Bearer token for ArgoCD (value passed to `--auth-token`). |
 | ARGOCD_APP_DIFF_SERVER_SIDE_DIFF | argocd_app_server_side_diff | no               |          | Set `--server-side-diff` for `argocd app diff` (`true`/`false`). |
-| ARGOCD_CLI_CMD_NAME              | N/A                         | no               | `argocd` | Overrides the `argocd` CLI command name (e.g., to use a specific argocd version); the named binary must be available on `PATH`. |
+| ARGOCD_CLI_CMD_NAME              | N/A                         | no               | `argocd` | Overrides the `argocd` CLI command name (e.g., to use a specific argocd version); accepts either a bare command name on `PATH` or an absolute path to the binary. |
 | ARGOCD_GRPC_WEB                  | argocd_grpc_web             | no               | `false`  | Set `--grpc-web` flag for argocd cli (`true`/`false`). |
 | ARGOCD_GRPC_WEB_ROOT_PATH        | argocd_grpc_web_root_path   | no               |          | Value for `--grpc-web-root-path` for argocd cli. |
 | ARGOCD_OPTS                      | argocd_opts                 | no               |          | Additional flags for argocd cli. |
@@ -270,7 +272,7 @@ $ go run cmd/main.go -f path/to/event_info.json
 ```
 
 > **Note:** argo-diff shells out to the `argocd` CLI, so a compatible `argocd` binary must be on your
-> `PATH` (override the command name with `ARGOCD_CLI_CMD_NAME`).
+> `PATH` (override the command name, or point at an absolute path, with `ARGOCD_CLI_CMD_NAME`).
 
 ### Craft a local file with event data
 

--- a/charts/argo-diff/README.md
+++ b/charts/argo-diff/README.md
@@ -20,6 +20,12 @@ $ helm install my-release oci://ghcr.io/vince-riv/chart/argo-diff
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| argocdCli | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"quay.io","repository":"argoproj/argocd","tag":""},"volumeSizeLimit":"2Gi"}` | Pin the version of the argocd CLI argo-diff runs, independent of the argo-diff image. |
+| argocdCli.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the argocd CLI initContainer |
+| argocdCli.image.registry | string | `"quay.io"` | Registry hosting the ArgoCD image the argocd CLI is copied from |
+| argocdCli.image.repository | string | `"argoproj/argocd"` | Repository of the ArgoCD image the argocd CLI is copied from |
+| argocdCli.image.tag | string | `""` | Tag of the ArgoCD image to copy the argocd CLI binary from; this is how you pin the version of the argocd CLI argo-diff runs (eg: "v3.4.6", or "v3.4.6@sha256:..." to also pin the digest). When set, an initContainer copies the argocd binary out of that image into a shared emptyDir volume and argo-diff is pointed at it via ARGOCD_CLI_CMD_NAME. When empty, argo-diff uses the argocd binary baked into its own image. |
+| argocdCli.volumeSizeLimit | string | `"2Gi"` | Max size of the emptyDir volume the argocd CLI binary is copied into |
 | command[0] | string | `"/app/argo-diff"` |  |
 | config.argocd.authToken | string | `""` |  |
 | config.argocd.grpcWeb | string | `""` |  |

--- a/charts/argo-diff/templates/deployment.yaml
+++ b/charts/argo-diff/templates/deployment.yaml
@@ -39,6 +39,25 @@ spec:
       serviceAccountName: {{ include "argo-diff.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.deployment.podSecurityContext | nindent 8 }}
+      {{- if .Values.argocdCli.image.tag }}
+      initContainers:
+        - name: argocd-cli
+          image: "{{ .Values.argocdCli.image.registry }}/{{ .Values.argocdCli.image.repository }}:{{ .Values.argocdCli.image.tag }}"
+          imagePullPolicy: {{ .Values.argocdCli.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              cp /usr/local/bin/argocd /argocd-cli/argocd
+              chmod 0755 /argocd-cli/argocd
+          securityContext:
+            {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
+          volumeMounts:
+            - name: argocd-cli
+              mountPath: /argocd-cli
+      {{- end }}
       containers:
         - name: argo-diff
           command: {{ .Values.command }}
@@ -53,6 +72,10 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
+            {{- if .Values.argocdCli.image.tag }}
+            - name: ARGOCD_CLI_CMD_NAME
+              value: "/argocd-cli/argocd"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "argo-diff.configMapName" . | quote }}
@@ -66,13 +89,27 @@ spec:
             {{- toYaml .Values.deployment.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
-          {{- with .Values.deployment.volumeMounts }}
+          {{- if or .Values.argocdCli.image.tag .Values.deployment.volumeMounts }}
           volumeMounts:
+            {{- if .Values.argocdCli.image.tag }}
+            - name: argocd-cli
+              mountPath: /argocd-cli
+              readOnly: true
+            {{- end }}
+            {{- with .Values.deployment.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.deployment.volumes }}
+      {{- if or .Values.argocdCli.image.tag .Values.deployment.volumes }}
       volumes:
+        {{- if .Values.argocdCli.image.tag }}
+        - name: argocd-cli
+          emptyDir:
+            sizeLimit: {{ .Values.argocdCli.volumeSizeLimit }}
+        {{- end }}
+        {{- with .Values.deployment.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:

--- a/charts/argo-diff/tests/deployment_test.yaml
+++ b/charts/argo-diff/tests/deployment_test.yaml
@@ -105,3 +105,123 @@ tests:
           content:
             configMapRef:
               name: testing-env
+  - it: argocd cli tag unset
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content: {name: ARGOCD_CLI_CMD_NAME, value: "/argocd-cli/argocd"}
+  - it: argocd cli tag set
+    set:
+      argocdCli.image.tag: "v3.4.6"
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: argocd-cli
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "quay.io/argoproj/argocd:v3.4.6"
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: IfNotPresent
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content: {name: argocd-cli, mountPath: /argocd-cli}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: argocd-cli
+            emptyDir:
+              sizeLimit: 2Gi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: {name: argocd-cli, mountPath: /argocd-cli, readOnly: true}
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: ARGOCD_CLI_CMD_NAME, value: "/argocd-cli/argocd"}
+  - it: argocd cli image and size overrides
+    set:
+      argocdCli.image.registry: "myregistry.example.com"
+      argocdCli.image.repository: "myorg/argocd"
+      argocdCli.image.tag: "v3.4.6"
+      argocdCli.image.pullPolicy: Always
+      argocdCli.volumeSizeLimit: 5Gi
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "myregistry.example.com/myorg/argocd:v3.4.6"
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: argocd-cli
+            emptyDir:
+              sizeLimit: 5Gi
+  - it: argocd cli digest-pinned tag
+    set:
+      argocdCli.image.tag: "v3.4.6@sha256:6e9f4f1dcbf1f2e3d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8"
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "quay.io/argoproj/argocd:v3.4.6@sha256:6e9f4f1dcbf1f2e3d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8"
+  - it: argocd cli alongside user volumes
+    set:
+      argocdCli.image.tag: "v3.4.6"
+      deployment.volumes:
+        - name: foo
+          secret:
+            secretName: mysecret
+      deployment.volumeMounts:
+        - name: foo
+          mountPath: "/etc/foo"
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: argocd-cli
+            emptyDir:
+              sizeLimit: 2Gi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: foo
+            secret:
+              secretName: mysecret
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: {name: argocd-cli, mountPath: /argocd-cli, readOnly: true}
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: {name: foo, mountPath: "/etc/foo"}
+  - it: argocd cli initContainer inherits deployment securityContext and resources
+    set:
+      argocdCli.image.tag: "v3.4.6"
+      deployment.securityContext:
+        runAsUser: 1000
+      deployment.resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 256Mi

--- a/charts/argo-diff/values.yaml
+++ b/charts/argo-diff/values.yaml
@@ -20,6 +20,24 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# argocdCli -- Pin the version of the argocd CLI argo-diff runs, independent of the argo-diff image.
+argocdCli:
+  image:
+    # argocdCli.image.registry -- Registry hosting the ArgoCD image the argocd CLI is copied from
+    registry: quay.io
+    # argocdCli.image.repository -- Repository of the ArgoCD image the argocd CLI is copied from
+    repository: argoproj/argocd
+    # argocdCli.image.tag -- Tag of the ArgoCD image to copy the argocd CLI binary from; this is how
+    # you pin the version of the argocd CLI argo-diff runs (eg: "v3.4.6", or "v3.4.6@sha256:..." to
+    # also pin the digest). When set, an initContainer copies the argocd binary out of that image
+    # into a shared emptyDir volume and argo-diff is pointed at it via ARGOCD_CLI_CMD_NAME. When
+    # empty, argo-diff uses the argocd binary baked into its own image.
+    tag: ""
+    # argocdCli.image.pullPolicy -- Image pull policy for the argocd CLI initContainer
+    pullPolicy: IfNotPresent
+  # argocdCli.volumeSizeLimit -- Max size of the emptyDir volume the argocd CLI binary is copied into
+  volumeSizeLimit: 2Gi
+
 imagePullSecrets: []
 
 config:

--- a/charts/context.md
+++ b/charts/context.md
@@ -31,6 +31,20 @@ them with `config.configMapName` / `secret.name`.
 ConfigMap. Adding one means touching `values.yaml` (with its `# key -- description` comment for
 helm-docs), `templates/configmap.yaml`, `tests/configmap_test.yaml`, and the README table.
 
+### Pinning the argocd CLI version (`argocdCli.*`)
+
+`ARGOCD_CLI_CMD_NAME` (see `internal/argocd/context.md`) lets argo-diff run an `argocd` binary other
+than the one baked into the image, but the chart previously had no way to reach it. `argocdCli.*`
+values fill that gap: when `argocdCli.image.tag` is set, `templates/deployment.yaml` adds an
+`initContainer` that copies `/usr/local/bin/argocd` out of the given ArgoCD image
+(`argocdCli.image.registry`/`repository`/`tag`) into a shared `emptyDir` volume (sized by
+`argocdCli.volumeSizeLimit`, default `2Gi`), mounted read-only into the `argo-diff` container at
+`/argocd-cli`. `ARGOCD_CLI_CMD_NAME` is set to `/argocd-cli/argocd` in that case, overriding any
+value supplied via `envFrom`. When `argocdCli.image.tag` is empty (the default), none of this
+renders and the deployment is unchanged — argo-diff uses the argocd binary baked in at build time.
+`argocdCli.image.tag` also accepts a digest suffix (`v3.4.6@sha256:...`) since there is no separate
+digest key.
+
 ### Versioning
 
 `version` and `appVersion` in `Chart.yaml` are bumped together by `scripts/prep-release.sh`, which


### PR DESCRIPTION
## Summary

Adds Helm chart values to pin the version of the `argocd` CLI that argo-diff runs, independent of the argo-diff image version, plus values to override the ArgoCD image's registry/repository used for that purpose.

- `argocdCli.image.tag` — tag of the ArgoCD image to copy the `argocd` CLI binary from (this is the version selector); also accepts a digest suffix (`v3.4.6@sha256:...`)
- `argocdCli.image.registry` / `argocdCli.image.repository` — override the ArgoCD image location (default `quay.io/argoproj/argocd`)
- `argocdCli.image.pullPolicy` — pull policy for the new initContainer
- `argocdCli.volumeSizeLimit` — max size of the shared `emptyDir` (default `2Gi`)

## Behavior

- **When `argocdCli.image.tag` is set:** the Deployment gains an `initContainer` that copies `/usr/local/bin/argocd` out of the specified ArgoCD image into an `emptyDir` volume (mounted read-only into the `argo-diff` container at `/argocd-cli`), and sets `ARGOCD_CLI_CMD_NAME=/argocd-cli/argocd` on the container so it uses that binary. This env var wins over any `envFrom` value.
- **When unset (default):** nothing renders — verified the manifest is byte-identical to the current chart output — and argo-diff uses the `argocd` binary baked into its own image via the `Dockerfile`.

This builds on existing Go support: `argocdCmdFromEnv()` (`internal/argocd/argocd_client.go`) already reads `ARGOCD_CLI_CMD_NAME` and accepts either a bare command name or an absolute path.

## Testing

- `helm lint charts/argo-diff` — passes
- `helm unittest charts/argo-diff` — 6 new test cases (on/off, image/size overrides, digest-pinned tag, coexistence with user-supplied `deployment.volumes`/`volumeMounts`, initContainer inheriting `deployment.securityContext`/`resources`), all 41 tests pass
- Confirmed `helm template` output is identical to `main` when the feature is unset
- `charts/argo-diff/README.md` regenerated via `helm-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)