### PR TITLE
chore(deps): exclude argocdCli.image.tag from Renovate management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
         "matchPackageNames": ["ghcr.io/vince-riv/argo-diff"],
         "pinDigests": false
     }, {
+        "matchManagers": ["helm-values"],
+        "matchFileNames": ["charts/argo-diff/values.yaml"],
+        "matchPackageNames": ["quay.io/argoproj/argocd"],
+        "enabled": false
+    }, {
         "matchPackageNames": [
             "google/go-github",
             "/^github\\.com/google/go-github/"


### PR DESCRIPTION
## Summary

Fixes #278 by stopping Renovate from proposing updates to `charts/argo-diff/values.yaml`'s `argocdCli.image.tag`.

## Problem

Renovate's `helm-values` manager auto-detects the `argocdCli.image.{registry,repository,tag}` triple as a Docker image reference (this is the standard `image: {registry, repository, tag}` shape Helm charts use) and tries to pin/bump it like any other image. But `argocdCli.image.tag` defaults to `""` intentionally — an empty tag is the on/off switch for the optional argocd-CLI-version-pinning initContainer (see #277), not a real version to track.

PR #278 demonstrates the resulting breakage: Renovate wrote `tag: "@sha256:077c2d8..."` — a digest with no tag prefix, which is not a valid image reference.

## Fix

Add a `packageRules` entry scoped to `matchManagers: ["helm-values"]` + `matchFileNames: ["charts/argo-diff/values.yaml"]` + `matchPackageNames: ["quay.io/argoproj/argocd"]`, with `enabled: false`. This disables Renovate for just this reference — the Dockerfile's own `quay.io/argoproj/argocd` digest pin (which legitimately tracks the baked-in argocd CLI version and should keep getting bumped) is unaffected, since the rule is scoped to the `helm-values` manager and this one file.

## Follow-up

Close #278 (superseded by this exclusion) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)