### PR TITLE
Handle GitHub App installation tokens passed via GITHUB_TOKEN

### DIFF
--- a/internal/github/comment.go
+++ b/internal/github/comment.go
@@ -155,6 +155,13 @@ func getCommentUser(ctx context.Context) error {
 			log.Info().Msgf("%s received when calling client.Users.Get() via go-github", resp.Status)
 		}
 		if err != nil {
+			// GitHub App installation tokens passed via GITHUB_TOKEN can't
+			// call GET /user (403). This is only a connectivity check —
+			// PR commenting works fine without commentLogin being set.
+			if resp != nil && resp.StatusCode == http.StatusForbidden {
+				log.Warn().Msg("GET /user returned 403 — GITHUB_TOKEN may be a GitHub App installation token. Skipping user lookup.")
+				return nil
+			}
 			log.Error().Err(err).Msg("Unable to determine get my github user")
 			return err
 		}


### PR DESCRIPTION
## Problem

When `GITHUB_TOKEN` contains a GitHub App installation token (common in CI systems like Jenkins), the startup connectivity check crashes:

```
GET https://api.github.com/user: 403 Resource not accessible by integration
Connectivity check to Github API failed
```

`GET /user` only works with PATs and OAuth tokens. GitHub App installation tokens get 403.

## Fix

When `Users.Get()` returns 403, log a warning and continue instead of crashing. The actual PR diff and commenting endpoints work fine with App tokens — only this health check breaks.

`commentLogin` will be empty, which means argo-diff won't match its own previous comments for updates. It will create new comments instead. This is acceptable — the tool still works.

## Context

argo-diff already supports GitHub Apps via `GITHUB_APP_ID` + `GITHUB_APP_INSTALLATION_ID` + `GITHUB_APP_PRIVATE_KEY`. But many CI systems (Jenkins, etc.) mint an installation token internally and pass it as `GITHUB_TOKEN`. This common pattern hits the bug because the code treats it as a PAT.