### PR TITLE
chore: fix golangci-lint findings after Go 1.26 upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ go test ./...                          # all tests
 go test -run TestName ./internal/argocd/...
 ```
 
-Requires Go 1.25+ (see `go.mod`). Builds inject the version via ldflags
+Requires Go 1.26+ (see `go.mod`). Builds inject the version via ldflags
 (`-X 'main.Version=...'`, from `git describe`); a plain `go build`/`go run` falls back to running
 `git describe` itself, defaulting to `dev`.
 

--- a/internal/argocd/helper.go
+++ b/internal/argocd/helper.go
@@ -62,7 +62,7 @@ func ConnectivityCheck() error {
 func appListToMap(appList []Application) map[string]Application {
 	argoAppMap := make(map[string]Application)
 	for _, app := range appList {
-		argoAppMap[app.ObjectMeta.Name] = app
+		argoAppMap[app.Name] = app
 	}
 	return argoAppMap
 }
@@ -72,19 +72,19 @@ func getApplicationChanges(ctx context.Context, app *Application, revision strin
 	var err error
 	appResChanges.ArgoApp = app
 	if revision != "" {
-		appResChanges.ChangedResources, err = diffApplication(ctx, app.ObjectMeta.Name, revision, nil, nil)
+		appResChanges.ChangedResources, err = diffApplication(ctx, app.Name, revision, nil, nil)
 	} else {
 		if len(revs) < 1 || len(revs) != len(pos) {
 			return appResChanges, fmt.Errorf("getApplicationChanges() called as multi-src with bad revs/pos count [%d/%d]", len(revs), len(pos))
 		}
-		appResChanges.ChangedResources, err = diffApplication(ctx, app.ObjectMeta.Name, "", revs, pos)
+		appResChanges.ChangedResources, err = diffApplication(ctx, app.Name, "", revs, pos)
 	}
 	return appResChanges, err
 }
 
 func getMultiSrcAppChanges(ctx context.Context, appCur *Application, appNew *Application, repoOwner, repoName, revision string) (ApplicationResourcesWithChanges, error) {
 	var appResChanges ApplicationResourcesWithChanges
-	appName := appCur.ObjectMeta.Name
+	appName := appCur.Name
 	curSources := appCur.Spec.GetSources()
 	newSources := appNew.Spec.GetSources()
 	if len(curSources) != len(newSources) {
@@ -292,9 +292,9 @@ func GetApplicationChanges(ctx context.Context, eventInfo webhook.EventInfo) ([]
 	log.Debug().Msgf("Matching apps: %s", func() (s string) {
 		for _, app := range apps {
 			if s != "" {
-				s += ", " + app.ObjectMeta.Name
+				s += ", " + app.Name
 			} else {
-				s += app.ObjectMeta.Name
+				s += app.Name
 			}
 		}
 		return
@@ -354,17 +354,17 @@ func GetApplicationChanges(ctx context.Context, eventInfo webhook.EventInfo) ([]
 	log.Debug().Msgf("Matching multi-source apps: %s", func() (s string) {
 		for _, app := range apps {
 			if s != "" {
-				s += ", " + app.ObjectMeta.Name
+				s += ", " + app.Name
 			} else {
-				s += app.ObjectMeta.Name
+				s += app.Name
 			}
 		}
 		return
 	}())
 	var wave3Apps []Application
 	for _, app := range apps {
-		if slices.Contains(multiSrcAppNamesDiffed, app.ObjectMeta.Name) {
-			log.Debug().Msgf("Skipping multi-source %s, we already diff'ed it", app.ObjectMeta.Name)
+		if slices.Contains(multiSrcAppNamesDiffed, app.Name) {
+			log.Debug().Msgf("Skipping multi-source %s, we already diff'ed it", app.Name)
 			continue
 		}
 		wave3Apps = append(wave3Apps, app)
@@ -406,7 +406,7 @@ func filterApplications(a []Application, eventInfo webhook.EventInfo, multiSourc
 			sources = []ApplicationSource{singleSrc}
 		}
 		for _, appSpecSource := range sources {
-			if checkSource(appSpecSource, app.ObjectMeta.Name, eventInfo, app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.Automated != nil) {
+			if checkSource(appSpecSource, app.Name, eventInfo, app.Spec.SyncPolicy != nil && app.Spec.SyncPolicy.Automated != nil) {
 				// Stop at the first matching source: an app is only diffed once, no
 				// matter how many of its sources point at the changed repo. A
 				// multi-source app in a monorepo commonly matches twice (eg: a chart
@@ -593,7 +593,7 @@ func argoAppsWithChanges(ctx context.Context, appName string, appResources []App
 		if err != nil {
 			log.Error().Err(err).Msg("Detected an argo application, but Unable to convert")
 		} else {
-			name := app.ObjectMeta.Name
+			name := app.Name
 			numSrcs := len(app.Spec.GetSources())
 			log.Trace().Msgf("argoAppsWithChanges(%s): argoApp %s w/ %d sources", appName, name, numSrcs)
 			if slices.Contains(argoAppNamesFound, name) && numSrcs > 0 {

--- a/internal/argocd/helper_test.go
+++ b/internal/argocd/helper_test.go
@@ -734,15 +734,16 @@ func TestManifestIsArgoApplication(t *testing.T) {
 	}
 	for i, manifest := range manifests {
 		isArgoApp := manifestIsArgoApplication(manifest)
-		if i == 0 || i == 1 {
+		switch i {
+		case 0, 1:
 			if isArgoApp {
 				t.Errorf("Manifest index %d in %s marked as Argo Application, but isn't", i, filepath)
 			}
-		} else if i == 2 || i == 3 {
+		case 2, 3:
 			if !isArgoApp {
 				t.Errorf("Manifest index %d in %s not marked as Argo Application, but is", i, filepath)
 			}
-		} else {
+		default:
 			t.Errorf("Expected 4 manifests in %s", filepath)
 		}
 	}

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -93,7 +93,7 @@ func newHttpTestServer(t *testing.T) *httptest.Server {
 						t.Errorf("readFileToByteArray() failed: %s", err)
 						return
 					}
-					payload = bytes.Replace(payload, []byte("%%_COMMENT_ID_%%"), []byte(urlPathParts[6]), -1)
+					payload = bytes.ReplaceAll(payload, []byte("%%_COMMENT_ID_%%"), []byte(urlPathParts[6]))
 					payload, err = jsonFieldExtract("body", reqBody, "body", payload)
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
@@ -118,7 +118,7 @@ func newHttpTestServer(t *testing.T) *httptest.Server {
 						t.Errorf("readFileToByteArray() failed: %s", err)
 						return
 					}
-					payload = bytes.Replace(payload, []byte("%%_PR_NUM_%%"), []byte(urlPathParts[5]), -1)
+					payload = bytes.ReplaceAll(payload, []byte("%%_PR_NUM_%%"), []byte(urlPathParts[5]))
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
 						t.Errorf("jsonFieldExtract() failed: %s", err)
@@ -134,23 +134,25 @@ func newHttpTestServer(t *testing.T) *httptest.Server {
 				statusCode = http.StatusOK
 				payload, filePath, err = readFileToByteArray(payloadUser)
 			case "/repos/vince-riv/argo-diff/issues/1/comments":
-				if r.Method == "GET" {
+				switch r.Method {
+				case "GET":
 					statusCode = http.StatusOK
 					payload, filePath, err = readFileToByteArray(payloadPr1Comments)
-				} else if r.Method == "POST" {
+				case "POST":
 					statusCode = http.StatusCreated
 					payload, filePath, err = readFileToByteArray(payloadPr1CreateComment)
-				} else {
+				default:
 					statusCode = http.StatusMethodNotAllowed
 				}
 			case "/repos/vince-riv/argo-diff/issues/2/comments":
-				if r.Method == "GET" {
+				switch r.Method {
+				case "GET":
 					statusCode = http.StatusOK
 					payload, filePath, err = readFileToByteArray(payloadPr2Comments)
-				} else if r.Method == "POST" {
+				case "POST":
 					statusCode = http.StatusCreated
 					payload, filePath, err = readFileToByteArray(payloadPr2CreateComment)
-				} else {
+				default:
 					statusCode = http.StatusMethodNotAllowed
 				}
 			case "/repos/vince-riv/argo-diff/issues/3/comments":

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -119,11 +119,6 @@ func newHttpTestServer(t *testing.T) *httptest.Server {
 						return
 					}
 					payload = bytes.ReplaceAll(payload, []byte("%%_PR_NUM_%%"), []byte(urlPathParts[5]))
-					if err != nil {
-						w.WriteHeader(http.StatusInternalServerError)
-						t.Errorf("jsonFieldExtract() failed: %s", err)
-						return
-					}
 				}
 			} else {
 				statusCode = http.StatusMethodNotAllowed

--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -94,7 +94,7 @@ func Status(ctx context.Context, status, description, repoOwner, repoName, commi
 	repoStatus := github.RepoStatus{
 		State:       &status,
 		Description: &description,
-		Context:     github.String(contextStr),
+		Context:     github.Ptr(contextStr),
 	}
 
 	if dryRun {

--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -92,8 +92,8 @@ func Status(ctx context.Context, status, description, repoOwner, repoName, commi
 	// TODO add support for AvatarURL ?
 	// TODO add support for TargetURL ?
 	repoStatus := github.RepoStatus{
-		State:       &status,
-		Description: &description,
+		State:       github.Ptr(status),
+		Description: github.Ptr(description),
 		Context:     github.Ptr(contextStr),
 	}
 

--- a/internal/process_event/code_change.go
+++ b/internal/process_event/code_change.go
@@ -165,7 +165,7 @@ func ProcessCodeChange(eventInfo webhook.EventInfo, devMode bool, wg *sync.WaitG
 	firstError := ""  // string of the first error we receive - used in commit status message
 	cMarkdown := github.CommentMarkdown{}
 	for _, a := range appResList {
-		appName := a.ArgoApp.ObjectMeta.Name
+		appName := a.ArgoApp.Name
 		appSyncStatus := a.ArgoApp.Status.Sync.Status
 		appHealthStatus := a.ArgoApp.Status.Health.Status
 		appHealthMsg := a.ArgoApp.Status.Health.Message


### PR DESCRIPTION
Repo was on Go 1.26 but hadn't had a full lint pass since the bump. Ran golangci-lint v2.12.2 (matching CI) via Docker and applied --fix for the auto-fixable findings, plus one manual fix:

- Simplify app.ObjectMeta.Name to app.Name (embedded field selector)
- bytes.Replace(..., -1) -> bytes.ReplaceAll(...)
- if/else if/else chains -> switch statements
- github.String(...) -> github.Ptr(...) (String is deprecated)

No behavior changes. go fmt was already clean. go build and go test both pass.

**Update:** follow-up cleanup from review:
- Removed a dead `err` check in `comment_test.go` (copy-paste leftover, `err` could never be non-nil there).
- Bumped AGENTS.md's stated Go requirement to 1.26+ to match `go.mod`.
- Made `status.go` consistently use `github.Ptr(...)` for all three `RepoStatus` fields.

Assisted-by: Claude Code (claude-sonnet-5)
