### PR TITLE
feat(chart): add PodDisruptionBudget and Deployment rollout strategy support

### DIFF
--- a/charts/argo-diff/templates/deployment.yaml
+++ b/charts/argo-diff/templates/deployment.yaml
@@ -13,6 +13,10 @@ metadata:
 spec:
   revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   replicas: {{ .Values.deployment.replicas }}
+  {{- with .Values.deployment.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-diff.selectorLabels" . | nindent 6 }}

--- a/charts/argo-diff/templates/pdb.yaml
+++ b/charts/argo-diff/templates/pdb.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+{{- if eq (int .Values.deployment.replicas) 1 }}
+{{/* allow scaling down to replicas=0 without erroring */}}
+{{- fail "podDisruptionBudget.enabled requires deployment.replicas > 1" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "argo-diff.fullname" . }}
+  namespace: {{ include "argo-diff.namespace" . }}
+  labels:
+    {{- include "argo-diff.labels" . | nindent 4 }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+  {{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive; set only one" }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "argo-diff.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/argo-diff/tests/deployment_test.yaml
+++ b/charts/argo-diff/tests/deployment_test.yaml
@@ -73,6 +73,24 @@ tests:
           content:
             configMapRef:
               name: RELEASE-NAME-argo-diff-env
+  - it: strategy override
+    set:
+      deployment.strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
   - it: non-helm-secret
     set:
       secret.create: false

--- a/charts/argo-diff/tests/pdb_test.yaml
+++ b/charts/argo-diff/tests/pdb_test.yaml
@@ -1,0 +1,54 @@
+---
+suite: pdb tests
+templates:
+  - pdb.yaml
+tests:
+  - it: is enabled
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 2
+    template: pdb.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          name: RELEASE-NAME-argo-diff
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: argo-diff
+            app.kubernetes.io/instance: RELEASE-NAME
+  - it: minAvailable only
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 2
+      podDisruptionBudget.minAvailable: 2
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+  - it: fails when both minAvailable and maxUnavailable are set
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 2
+      podDisruptionBudget.minAvailable: 2
+      podDisruptionBudget.maxUnavailable: 1
+    template: pdb.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive; set only one"
+  - it: fails when replicas==1 (default)
+    set:
+      podDisruptionBudget.enabled: true
+    template: pdb.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.enabled requires deployment.replicas > 1"

--- a/charts/argo-diff/values.yaml
+++ b/charts/argo-diff/values.yaml
@@ -120,6 +120,14 @@ deployment:
   replicas: 1
   revisionHistoryLimit: 5
 
+  # deployment.strategy -- Rollout strategy for the Deployment (See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
+  # Defaults to Kubernetes' own default (RollingUpdate, 25% maxSurge/maxUnavailable) when left empty
+  strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
   # deployment.livenessProbe -- Configuration for liveness check. (See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   livenessProbe:
     httpGet:
@@ -202,3 +210,18 @@ service:
   annotations: {}
   type: ClusterIP
   port: 8080
+
+podDisruptionBudget:
+  # podDisruptionBudget.enabled -- Create a PodDisruptionBudget
+  enabled: false
+  # podDisruptionBudget.annotations -- Annotations to add to the PodDisruptionBudget
+  annotations: {}
+  # podDisruptionBudget.minAvailable -- Minimum number/percentage of pods that must remain available.
+  # Mutually exclusive with maxUnavailable
+  minAvailable: ""
+  # podDisruptionBudget.maxUnavailable -- Maximum number/percentage of pods that can be unavailable.
+  # Mutually exclusive with minAvailable
+  maxUnavailable: ""
+  # podDisruptionBudget.unhealthyPodEvictionPolicy -- Eviction policy for unhealthy pods
+  # (IfHealthyBudget or AlwaysAllow). Requires Kubernetes 1.27+
+  unhealthyPodEvictionPolicy: ""


### PR DESCRIPTION
## Summary
- Add an optional `podDisruptionBudget` resource to the `argo-diff` Helm chart, so operators can protect pods from voluntary disruptions (node drains, cluster autoscaler)
- Add `deployment.strategy` to let operators override the Deployment's rollout strategy instead of relying on Kubernetes' default (RollingUpdate, 25%/25%)

## Details
- `templates/pdb.yaml` fails to render if `deployment.replicas == 1` (a PDB is either a no-op or blocks node drains forever at that replica count), and if `minAvailable`/`maxUnavailable` are both set (Kubernetes itself rejects a PDB spec with both fields populated)
- `deployment.replicas: 0` (scale-to-zero) is allowed — the PDB selector simply matches no pods
- New `tests/pdb_test.yaml` and additions to `tests/deployment_test.yaml` cover both features

## Test plan
- [x] `helm lint charts/argo-diff`
- [x] `helm unittest charts/argo-diff` (all suites pass)
- [ ] Reviewer: confirm chart version bump policy — none included here per `scripts/prep-release.sh` convention (bumped at release time, not per-PR)

Assisted-by: Claude Code (claude-opus-4-6)