### PR TITLE
fix(chart): preserve zero values for PDB minAvailable/maxUnavailable

### DIFF
--- a/charts/argo-diff/README.md
+++ b/charts/argo-diff/README.md
@@ -58,6 +58,7 @@ $ helm install my-release oci://ghcr.io/vince-riv/chart/argo-diff
 | deployment.revisionHistoryLimit | int | `5` |  |
 | deployment.securityContext | object | `{}` |  |
 | deployment.startupProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/healthz","port":"http"},"periodSeconds":2}` | Configuration for startup check. (See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| deployment.strategy | object | `{}` | Rollout strategy for the Deployment (See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). Defaults to Kubernetes' own default (RollingUpdate, 25% maxSurge/maxUnavailable) when left empty |
 | deployment.tolerations | list | `[]` |  |
 | deployment.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | deployment.volumes | list | `[]` | Additional volumes on the output Deployment definition. |
@@ -77,6 +78,11 @@ $ helm install my-release oci://ghcr.io/vince-riv/chart/argo-diff
 | logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
+| podDisruptionBudget.annotations | object | `{}` | Annotations to add to the PodDisruptionBudget |
+| podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget |
+| podDisruptionBudget.maxUnavailable | string | `""` | Maximum number/percentage of pods that can be unavailable. Mutually exclusive with minAvailable |
+| podDisruptionBudget.minAvailable | string | `""` | Minimum number/percentage of pods that must remain available. Mutually exclusive with maxUnavailable |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Eviction policy for unhealthy pods (IfHealthyBudget or AlwaysAllow). Requires Kubernetes 1.27+ |
 | secret.annotations | object | `{}` |  |
 | secret.create | bool | `true` | Have Helm create Secret from values. If disabled, you need to manage sensitive environment variables |
 | secret.name | string | `""` | Override the name of the secret passed to deployment's envFrom. Defaults to release name. Should contain the following keys ARGOCD_AUTH_TOKEN, GITHUB_WEBHOOK_SECRET, and GITHUB_PERSONAL_ACCESS_TOKEN/GITHUB_APP_PRIVATE_KEY |

--- a/charts/argo-diff/templates/pdb.yaml
+++ b/charts/argo-diff/templates/pdb.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
+{{- $min := toString .Values.podDisruptionBudget.minAvailable }}
+{{- $max := toString .Values.podDisruptionBudget.maxUnavailable }}
 {{- if eq (int .Values.deployment.replicas) 1 }}
-{{/* allow scaling down to replicas=0 without erroring */}}
-{{- fail "podDisruptionBudget.enabled requires deployment.replicas > 1" }}
+{{/* allow scaling down to replicas=0 without erroring; only block a config that would
+   actually deadlock node drains at replicas=1 (minAvailable>=1, or maxUnavailable=0) */}}
+{{- if or (and (ne $min "") (ne $min "0")) (eq $max "0") }}
+{{- fail "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever" }}
+{{- end }}
 {{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,13 +20,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if and (ne $min "") (ne $max "") }}
   {{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive; set only one" }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- if ne $min "" }}
+  minAvailable: {{ $min }}
   {{- else }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
+  maxUnavailable: {{ $max | default "1" }}
   {{- end }}
   {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ . }}

--- a/charts/argo-diff/tests/pdb_test.yaml
+++ b/charts/argo-diff/tests/pdb_test.yaml
@@ -3,6 +3,11 @@ suite: pdb tests
 templates:
   - pdb.yaml
 tests:
+  - it: is disabled by default
+    template: pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: is enabled
     set:
       podDisruptionBudget.enabled: true
@@ -45,10 +50,78 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive; set only one"
-  - it: fails when replicas==1 (default)
+  - it: renders at replicas==1 with default maxUnavailable
     set:
       podDisruptionBudget.enabled: true
     template: pdb.yaml
     asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+  - it: fails when replicas==1 and maxUnavailable is zero
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.maxUnavailable: 0
+    template: pdb.yaml
+    asserts:
       - failedTemplate:
-          errorMessage: "podDisruptionBudget.enabled requires deployment.replicas > 1"
+          errorMessage: "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever"
+  - it: fails when replicas==1 and minAvailable is set
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 1
+    template: pdb.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever"
+  - it: maxUnavailable zero is preserved
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 3
+      podDisruptionBudget.maxUnavailable: 0
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
+  - it: minAvailable zero is preserved
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 3
+      podDisruptionBudget.minAvailable: 0
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 0
+      - notExists:
+          path: spec.maxUnavailable
+  - it: fails when minAvailable set with maxUnavailable zero
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 3
+      podDisruptionBudget.minAvailable: 2
+      podDisruptionBudget.maxUnavailable: 0
+    template: pdb.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive; set only one"
+  - it: renders at replicas==0 (scale-to-zero)
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 0
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+  - it: unhealthyPodEvictionPolicy is set
+    set:
+      podDisruptionBudget.enabled: true
+      deployment.replicas: 2
+      podDisruptionBudget.unhealthyPodEvictionPolicy: AlwaysAllow
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow

--- a/charts/context.md
+++ b/charts/context.md
@@ -10,9 +10,21 @@ Two Helm charts with very different purposes:
 ## charts/argo-diff
 
 Templates render a Deployment (with `/healthz` liveness, readiness, and startup probes), Service,
-optional Ingress, ServiceAccount, and — when enabled — the ConfigMap and Secret holding argo-diff's
-environment variables. The Deployment consumes both via `envFrom` and annotates the pod with
+optional Ingress, ServiceAccount, and — when enabled — the ConfigMap, Secret, and PodDisruptionBudget.
+The Deployment consumes the ConfigMap/Secret via `envFrom` and annotates the pod with
 `checksum/config` / `checksum/secret` so a config change triggers a rollout.
+
+`deployment.strategy` overrides the Deployment's rollout strategy; left empty (the default), the
+Deployment omits the field and Kubernetes applies its own default (RollingUpdate, 25%/25%).
+
+`templates/pdb.yaml` (`podDisruptionBudget.enabled`) hard-fails the template render — via Helm's
+`fail`, not a Kubernetes-side error — in two cases: `minAvailable`/`maxUnavailable` both set
+(Kubernetes itself rejects a PDB spec with both fields populated), and at
+`deployment.replicas == 1` only when the given `minAvailable`/`maxUnavailable` would actually
+deadlock a node drain (`minAvailable >= 1`, or `maxUnavailable: 0`) — the harmless default
+(`maxUnavailable: 1`) still renders. Compare `minAvailable`/`maxUnavailable` as strings, not as
+Helm truthiness — Go templates treat `0` as falsy, so a bare truthiness check silently drops
+`maxUnavailable: 0` / `minAvailable: 0`.
 
 Configuration split:
 


### PR DESCRIPTION
## Summary
Follow-up to #302. Fixes a bug from that PR's own code review, caught before merge but merged anyway.

- `maxUnavailable: 0` and `minAvailable: 0` are falsy in Go templates. `templates/pdb.yaml` treated an unset value and an explicit `0` the same way, so `maxUnavailable: 0` silently rendered as `1`, and `minAvailable: 0` fell through to the `maxUnavailable` branch. Fixed by comparing both values as strings, so only `""` means "unset".
- Narrows the `deployment.replicas == 1` guard: it now only hard-fails when the given `minAvailable`/`maxUnavailable` would actually deadlock a node drain (`minAvailable >= 1`, or `maxUnavailable: 0`). The default `maxUnavailable: 1` is a harmless no-op at one replica and now renders instead of failing the chart install.
- Regenerates `README.md` via `helm-docs` and documents the PDB/strategy templates in `charts/context.md` — both were missed in #302.

## Test plan
- [x] New tests added first and confirmed failing against #302's merged code, to verify the bug.
- [x] `helm unittest charts/argo-diff` — 49/49 pass after the fix.
- [x] `helm lint charts/argo-diff`

Assisted-by: Claude Code (claude-sonnet-5)