### PR TITLE
fix(chart): handle percentage PDB values in the replicas=1 guard

### DIFF
--- a/charts/argo-diff/templates/pdb.yaml
+++ b/charts/argo-diff/templates/pdb.yaml
@@ -1,10 +1,15 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
 {{- $min := toString .Values.podDisruptionBudget.minAvailable }}
 {{- $max := toString .Values.podDisruptionBudget.maxUnavailable }}
+{{/* Kubernetes scales a percentage against the replica count and rounds up, so at one replica
+   every non-zero percentage behaves like its integer equivalent. Only an explicit zero differs,
+   so strip the '%' before testing for it and treat "0" and "0%" alike. */}}
+{{- $minIsZero := eq (trimSuffix "%" $min) "0" }}
+{{- $maxIsZero := eq (trimSuffix "%" $max) "0" }}
 {{- if eq (int .Values.deployment.replicas) 1 }}
 {{/* allow scaling down to replicas=0 without erroring; only block a config that would
    actually deadlock node drains at replicas=1 (minAvailable>=1, or maxUnavailable=0) */}}
-{{- if or (and (ne $min "") (ne $min "0")) (eq $max "0") }}
+{{- if or (and (ne $min "") (not $minIsZero)) $maxIsZero }}
 {{- fail "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever" }}
 {{- end }}
 {{- end }}

--- a/charts/argo-diff/tests/pdb_test.yaml
+++ b/charts/argo-diff/tests/pdb_test.yaml
@@ -74,6 +74,44 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever"
+  - it: fails when replicas==1 and maxUnavailable is zero percent
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.maxUnavailable: "0%"
+    template: pdb.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever"
+  - it: fails when replicas==1 and minAvailable is a non-zero percentage
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: "50%"
+    template: pdb.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget at deployment.replicas=1 with this minAvailable/maxUnavailable blocks node drains forever"
+  - it: renders at replicas==1 with minAvailable zero percent
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: "0%"
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "0%"
+      - notExists:
+          path: spec.maxUnavailable
+  - it: renders at replicas==1 with a non-zero maxUnavailable percentage
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.maxUnavailable: "50%"
+    template: pdb.yaml
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "50%"
+      - notExists:
+          path: spec.minAvailable
   - it: maxUnavailable zero is preserved
     set:
       podDisruptionBudget.enabled: true

--- a/charts/context.md
+++ b/charts/context.md
@@ -26,6 +26,12 @@ deadlock a node drain (`minAvailable >= 1`, or `maxUnavailable: 0`) — the harm
 Helm truthiness — Go templates treat `0` as falsy, so a bare truthiness check silently drops
 `maxUnavailable: 0` / `minAvailable: 0`.
 
+The `replicas == 1` guard also has to handle percentages. Kubernetes scales a percentage against
+the replica count and rounds *up*, so at one replica every non-zero percentage collapses to `1` and
+behaves like the integer — `minAvailable: 50%` deadlocks, `maxUnavailable: 50%` does not. Only an
+explicit zero differs, so the guard strips a trailing `%` and treats `"0"` and `"0%"` alike. Above
+one replica percentages are left to Kubernetes; the guard does not run.
+
 Configuration split:
 
 - **ConfigMap** (`config.configMapCreate`): non-sensitive vars — `ARGOCD_SERVER_ADDR`,


### PR DESCRIPTION
## Summary

Follow-up to #303. The `deployment.replicas == 1` deadlock guard in `templates/pdb.yaml` compared `minAvailable`/`maxUnavailable` against the literal strings `""` and `"0"`, so percentage values fell on the wrong side of it in both directions:

- `maxUnavailable: "0%"` was not `"0"`, so the guard let it render. At one replica Kubernetes computes zero allowed disruptions from it — exactly the node-drain deadlock the guard exists to prevent.
- `minAvailable: "0%"` was neither `""` nor `"0"`, so the guard hard-failed the render even though zero percent always permits eviction.

Kubernetes scales a percentage against the replica count and rounds up, so at one replica every non-zero percentage collapses to 1 and behaves like the equivalent integer — only an explicit zero differs. The guard now strips a trailing `%` before the zero test, so `"0"` and `"0%"` are treated alike, and the non-zero percentage cases fall through to the existing integer logic.

Behavior at `deployment.replicas: 1`:

| Value | Before | After |
| --- | --- | --- |
| `maxUnavailable: "0%"` | rendered (deadlocks drains) | fails |
| `minAvailable: "0%"` | failed (false alarm) | renders |
| `minAvailable: "50%"` | fails | fails (unchanged) |
| `maxUnavailable: "50%"` | renders | renders (unchanged) |

No values changed, so `README.md` needs no `helm-docs` regeneration. `charts/context.md` documents the rounding rule and why the guard strips `%`.

## Test plan

- [x] Four new cases in `tests/pdb_test.yaml`, one per row of the table above. Added first and confirmed the two changed rows failed against #303's merged code.
- [x] `helm unittest charts/argo-diff` — 53/53 pass after the fix.
- [x] `helm lint charts/argo-diff`

Assisted-by: Claude Code (claude-opus-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)