### PR TITLE
fix(ci): skip Docker push step on fork PRs

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -103,7 +103,8 @@ jobs:
             type=sha,event=pr
       -
         name: Build and push linux/amd64
-        if: ${{ github.event_name == 'pull_request' }} ## only push amd64 on PRs
+        ## only push amd64 on PRs, and only when the PR is not from a fork (forks can't push to ghcr.io)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .


### PR DESCRIPTION
Fork PRs can't push to ghcr.io, so the "Build and push linux/amd64" step in the `go-build-and-docker-buildx` job always failed on fork PRs. This adds a fork check to the step's `if:` condition, so the push only runs for `pull_request` events where the PR's head repo matches the base repo (i.e. branches on this repo, not forks) — the standard proxy for "PR opened by a maintainer/collaborator". Fork PRs now skip the step entirely instead of failing.

Assisted-by: Claude Code (claude-sonnet-5)