### PR TITLE
feat(ci): k3s e2e test on fork PRs; don't dockerbuild PRs

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -77,6 +77,7 @@ jobs:
 
       -
         name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       -
         name: Set up Docker Buildx
@@ -84,6 +85,7 @@ jobs:
       -
         name: Log in to container register
         id: login-ghcr
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -92,6 +94,7 @@ jobs:
       -
         name: Docker meta
         id: meta
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -99,19 +102,17 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=sha,event=branch
-            type=ref,event=pr
-            type=sha,event=pr
       -
-        name: Build and push linux/amd64
-        ## only push amd64 on PRs, and only when the PR is not from a fork (forks can't push to ghcr.io)
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        name: Build linux/amd64 (no push)
+        ## PRs only validate that the image builds - the k3s e2e test builds its
+        ## own image, and publishing happens on push to main / release tags.
+        if: ${{ github.event_name == 'pull_request' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          tags: argo-diff:pr
           platforms: linux/amd64
       -
         name: Build and push multi-arch

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -13,10 +13,11 @@ on:
       - 'Dockerfile'
   pull_request:
     branches: [main, "release-*"]
+    # PRs no longer push an image, so the only thing left to validate here is
+    # that the release tooling still builds. Scope to the files that can break
+    # it - go.yml covers plain Go compilation, and the push trigger above still
+    # catches multi-arch breakage from .go / go.mod changes on merge.
     paths:
-      - '**/**.go'
-      - 'go.mod'
-      - 'go.sum'
       - '.github/workflows/dockerbuild.yml'
       - '.goreleaser.yaml'
       - 'Dockerfile'

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -106,7 +106,8 @@ jobs:
       -
         name: Build linux/amd64 (no push)
         ## PRs only validate that the image builds - the k3s e2e test builds its
-        ## own image, and publishing happens on push to main / release tags.
+        ## own image, and publishing happens on push to main / release-* branches
+        ## (this workflow has no tag trigger; release.yml owns tag publishing).
         if: ${{ github.event_name == 'pull_request' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:

--- a/.github/workflows/k3s.yml
+++ b/.github/workflows/k3s.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'Pull request number to test (use this for fork PRs)'
+        description: 'PR number to test (fork-PR path). Review the fork diff first: the run executes PR code with a pull-requests:write token.'
         required: true
         type: string
   pull_request:
@@ -19,6 +19,11 @@ on:
       - 'go.sum'
       - 'Dockerfile'
 
+# SECURITY: on workflow_dispatch this job checks out and runs PR-authored code
+# (go build, docker build, test/run-argo-diff-pod.sh) with the token below. A
+# maintainer must review the fork's diff before dispatching. The token is held
+# to pull-requests:write (comment post/edit) - no contents or packages write -
+# which bounds the blast radius of a malicious fork PR.
 permissions:
   contents: read
   pull-requests: write
@@ -58,10 +63,11 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            # Fork PRs expose no PR context in the event payload, so read it
-            # back from the API using the dispatched PR number.
-            PR_NUMBER="$DISPATCH_PR"
-            pr_json=$(gh pr view "$PR_NUMBER" --json headRefName,baseRefName,headRefOid)
+            # Fork PRs expose no PR context in the event payload, so read it back
+            # from the API. `gh pr view` accepts a number, "#123", or a PR URL;
+            # .number normalizes whatever was typed to the canonical integer.
+            pr_json=$(gh pr view "$DISPATCH_PR" --json number,headRefName,baseRefName,headRefOid)
+            PR_NUMBER=$(jq -r '.number' <<<"$pr_json")
             HEAD_REF=$(jq -r '.headRefName' <<<"$pr_json")
             BASE_REF=$(jq -r '.baseRefName' <<<"$pr_json")
             HEAD_SHA=$(jq -r '.headRefOid' <<<"$pr_json")
@@ -94,9 +100,12 @@ jobs:
         id: git_checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # The PR merge ref works for same-repo and fork PRs alike, so the
-          # workflow scripts and test fixtures come from the PR under test.
-          ref: refs/pull/${{ steps.pr_info.outputs.PR_NUMBER }}/merge
+          # Check out the resolved head commit, not refs/pull/<n>/merge: the
+          # merge ref is absent when the PR has conflicts and can move if the PR
+          # author pushes mid-run. A pinned sha always exists and matches the
+          # HEAD_SHA we report. argo-diff computes the real diff against the live
+          # PR via the API, so a local merge preview would add nothing.
+          ref: ${{ steps.pr_info.outputs.HEAD_SHA }}
           fetch-depth: '50'
           fetch-tags: 'true'
 

--- a/.github/workflows/k3s.yml
+++ b/.github/workflows/k3s.yml
@@ -2,15 +2,22 @@
 name: K3s Argo-Diff Test
 
 on:
-  workflow_run:
-    workflows: ["Docker build"]
-    types:
-      - completed
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Pull request number to test (use this for fork PRs)'
+        required: true
+        type: string
   pull_request:
     branches: ["main"]
     paths:
       - '.github/workflows/k3s.yml'
       - 'test/**'
+      - 'charts/test-basic-deployment/**'
+      - '**/**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
 
 permissions:
   contents: read
@@ -18,11 +25,18 @@ permissions:
 
 env:
   ARGOCD_OPTS: '--port-forward --port-forward-namespace argocd --insecure --plaintext'
+  # Built in-workflow and side-loaded into k3d - never pushed to a registry, so
+  # this test has no dependency on the "Docker build" workflow or ghcr.io.
+  ARGO_DIFF_IMAGE: argo-diff:e2e
 
 jobs:
   k3s:
-    # Only run on pull_request events or successful workflow_run from dockerbuild in a pull request
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success') }}
+    # workflow_dispatch: always. This is the manual path for fork PRs - a fork
+    # PR gets a read-only GITHUB_TOKEN on pull_request and cannot post the
+    # argo-diff comment, and github.event.workflow_run.pull_requests was always
+    # empty for forks, so the old workflow_run path could not resolve them.
+    # pull_request: only for same-repo branches; fork PRs must use workflow_dispatch.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: false
       matrix:
@@ -30,42 +44,81 @@ jobs:
     name: K8s ${{ matrix.k8s }}
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR context
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR: ${{ github.event.inputs.pr }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_REF: ${{ github.head_ref }}
+          EVENT_BASE_REF: ${{ github.base_ref }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Fork PRs expose no PR context in the event payload, so read it
+            # back from the API using the dispatched PR number.
+            PR_NUMBER="$DISPATCH_PR"
+            pr_json=$(gh pr view "$PR_NUMBER" --json headRefName,baseRefName,headRefOid)
+            HEAD_REF=$(jq -r '.headRefName' <<<"$pr_json")
+            BASE_REF=$(jq -r '.baseRefName' <<<"$pr_json")
+            HEAD_SHA=$(jq -r '.headRefOid' <<<"$pr_json")
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            HEAD_REF="$EVENT_HEAD_REF"
+            BASE_REF="$EVENT_BASE_REF"
+            HEAD_SHA="$EVENT_HEAD_SHA"
+          fi
+
+          if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+            echo "::error::Could not determine a PR number to test"
+            exit 1
+          fi
+
+          {
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "HEAD_REF=${HEAD_REF}"
+            echo "BASE_REF=${BASE_REF}"
+            echo "HEAD_SHA=${HEAD_SHA}"
+            echo "PR_REF=refs/pull/${PR_NUMBER}/merge"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "PR number: ${PR_NUMBER}"
+          echo "Head ref (source branch): ${HEAD_REF}"
+          echo "Base ref (target branch): ${BASE_REF}"
+          echo "Head sha: ${HEAD_SHA}"
+
       - name: Git Checkout
         id: git_checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # The PR merge ref works for same-repo and fork PRs alike, so the
+          # workflow scripts and test fixtures come from the PR under test.
+          ref: refs/pull/${{ steps.pr_info.outputs.PR_NUMBER }}/merge
+          fetch-depth: '50'
+          fetch-tags: 'true'
 
-      - name: Determine argo-diff image tag and PR refs
-        id: pr_info
-        env:
-          PR_DATA: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+      - name: Set up Go
+        id: setup_go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Build argo-diff binary
+        id: go_build
+        timeout-minutes: 3
         run: |
-          # Default values
-          IMAGE_TAG="main"
-          HEAD_REF="${{ github.head_ref }}"
-          BASE_REF="${{ github.base_ref }}"
-          PR_REF="${{ github.ref }}"
+          mkdir -p temp
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+            -ldflags "-s -w -X main.Version=$(git describe --tags --always --dirty 2>/dev/null || echo e2e)" \
+            -o temp/argo-diff-linux-amd64 ./cmd
 
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
-            # Triggered by dockerbuild.yml workflow on a PR - extract PR context from workflow_run
-            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.[0].number')
-            HEAD_REF=$(echo "$PR_DATA" | jq -r '.[0].head.ref')
-            BASE_REF=$(echo "$PR_DATA" | jq -r '.[0].base.ref')
-            if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then
-              IMAGE_TAG="pr-${PR_NUMBER}"
-              PR_REF="refs/pull/${PR_NUMBER}/merge"
-            fi
-          fi
-
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "HEAD_REF=${HEAD_REF}" >> $GITHUB_OUTPUT
-          echo "BASE_REF=${BASE_REF}" >> $GITHUB_OUTPUT
-          echo "PR_REF=${PR_REF}" >> $GITHUB_OUTPUT
-          echo "Using argo-diff image tag: ${IMAGE_TAG}"
-          echo "Head ref (source branch): ${HEAD_REF}"
-          echo "Base ref (target branch): ${BASE_REF}"
-          echo "PR ref: ${PR_REF}"
+      - name: Build argo-diff image
+        id: docker_build
+        timeout-minutes: 3
+        run: docker build --build-arg TARGETARCH=amd64 -t "$ARGO_DIFF_IMAGE" -f Dockerfile .
 
       - name: K3d/K3s Setup
         id: k3s_setup
@@ -79,6 +132,15 @@ jobs:
         id: k3s_verify
         timeout-minutes: 1
         run: kubectl version
+
+      - name: Import argo-diff image into k3d
+        id: k3d_import
+        timeout-minutes: 2
+        run: |
+          set -euo pipefail
+          cluster=$(k3d cluster list -o json | jq -r '.[0].name')
+          echo "Importing $ARGO_DIFF_IMAGE into k3d cluster: $cluster"
+          k3d image import "$ARGO_DIFF_IMAGE" --cluster "$cluster"
 
       - name: Install ArgoCD via HelmChart CRD
         id: argocd_install
@@ -161,9 +223,9 @@ jobs:
         timeout-minutes: 2
         env:
           POD_NAME_PREFIX: argo-diff-healthy
-          IMAGE_TAG: ${{ steps.pr_info.outputs.IMAGE_TAG }}
+          IMAGE: ${{ env.ARGO_DIFF_IMAGE }}
           ARGO_DIFF_CONTEXT_STR: ephemeral-environment-test
-          ARGO_DIFF_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ARGO_DIFF_SHA: ${{ steps.pr_info.outputs.HEAD_SHA }}
           ARGO_DIFF_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
           ARGO_DIFF_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -190,9 +252,9 @@ jobs:
         timeout-minutes: 2
         env:
           POD_NAME_PREFIX: argo-diff-failure
-          IMAGE_TAG: ${{ steps.pr_info.outputs.IMAGE_TAG }}
+          IMAGE: ${{ env.ARGO_DIFF_IMAGE }}
           ARGO_DIFF_CONTEXT_STR: ephemeral-environment-test-failure
-          ARGO_DIFF_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ARGO_DIFF_SHA: ${{ steps.pr_info.outputs.HEAD_SHA }}
           ARGO_DIFF_HEAD_REF: ${{ steps.pr_info.outputs.HEAD_REF }}
           ARGO_DIFF_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ changes.
 | `docs/` | Screenshots and example raw Kubernetes manifests |
 | `scripts/` | `prep-release.sh` — bumps every version-pinned file before a release |
 | `test/` | Fixtures and runner for the k3s end-to-end test |
-| `temp/` | Gitignored scratch dir used by the Docker build and `post-local.sh` |
+| `temp/` | Gitignored scratch dir used by Docker image builds (dockerbuild + k3s e2e) and `post-local.sh` |
 
 ## Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ mocking points — see the relevant `context.md`.
 Workflows in `.github/workflows/`:
 
 - **go.yml** — build, `go fmt`, tests, and lint (golangci-lint v2, `only-new-issues`; PRs only).
-- **dockerbuild.yml** — GoReleaser build + multi-arch image publish to `ghcr.io`.
+- **dockerbuild.yml** — GoReleaser build + multi-arch image publish to `ghcr.io` (on `push` / tags; PRs build only, no push).
 - **k3s.yml** — end-to-end test on a k3s cluster with ArgoCD, using `test/` (see `test/context.md`).
 - **release.yml** — cuts a release on an `X.Y.Z[-suffix]` tag and moves the floating `vX` /
   `actions-vX` tags.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ mocking points — see the relevant `context.md`.
 Workflows in `.github/workflows/`:
 
 - **go.yml** — build, `go fmt`, tests, and lint (golangci-lint v2, `only-new-issues`; PRs only).
-- **dockerbuild.yml** — GoReleaser build + multi-arch image publish to `ghcr.io` (on `push` / tags; PRs build only, no push).
+- **dockerbuild.yml** — GoReleaser build + multi-arch image publish to `ghcr.io` on `push` to `main` / `release-*` (no tag trigger; PRs build only, no push).
 - **k3s.yml** — end-to-end test on a k3s cluster with ArgoCD, using `test/` (see `test/context.md`).
 - **release.yml** — cuts a release on an `X.Y.Z[-suffix]` tag and moves the floating `vX` /
   `actions-vX` tags.

--- a/test/context.md
+++ b/test/context.md
@@ -30,9 +30,13 @@ should show up in the e2e diff has to be reflected there too.
 
 ## run-argo-diff-pod.sh
 
-Required env: `POD_NAME_PREFIX`, `IMAGE_TAG`, `ARGO_DIFF_CONTEXT_STR`, `ARGO_DIFF_SHA`,
+Required env: `POD_NAME_PREFIX`, `IMAGE`, `ARGO_DIFF_CONTEXT_STR`, `ARGO_DIFF_SHA`,
 `ARGO_DIFF_HEAD_REF`, `ARGO_DIFF_REPOSITORY`, `GITHUB_TOKEN`, `PR_REF`, `EXPECT_EXIT`
 (`0` or `nonzero`). Optional `REQUIRE_LOG` asserts a substring appears in the pod logs.
+
+`IMAGE` is a full image reference (`argo-diff:e2e`). `k3s.yml` builds it from the PR's own source
+and side-loads it into k3d, so the pod runs with `imagePullPolicy: Never` and there is no registry
+dependency.
 
 The `ARGO_DIFF_*` names exist because `GITHUB_SHA`, `GITHUB_HEAD_REF`, and `GITHUB_REPOSITORY` are
 GitHub Actions' reserved defaults — a step's own `env:` block cannot override them, so the script
@@ -45,10 +49,28 @@ phase, prints the logs, and compares the container's exit code against `EXPECT_E
 
 ## Workflow shape
 
-`k3s.yml` runs on PRs touching `test/**` or the workflow itself, and on a successful `Docker build`
-`workflow_run` (so it can test the `pr-<n>` image built from that PR). It runs two scenarios:
-the healthy apps (`EXPECT_EXIT=0`), then — after deleting `meta` (finalizer removed first, since its
-`selfHeal` would resurrect its children) and applying the broken app — the failure case
-(`EXPECT_EXIT=nonzero`, `REQUIRE_LOG="Failed to diff application broken-deployment"`).
+`k3s.yml` has two triggers:
 
-Both runs comment on the PR, so their output is visible on the PR that triggered them.
+- **`pull_request`** — same-repo branches only, on paths that affect the test: `test/**`, the
+  workflow itself, `charts/test-basic-deployment/**`, any `.go` file, `go.mod`/`go.sum`, `Dockerfile`.
+  The job `if:` skips fork PRs, because a fork PR gets a read-only `GITHUB_TOKEN` and cannot post the
+  argo-diff comment.
+- **`workflow_dispatch`** with a required `pr` input — the manual path for **fork PRs**. A maintainer
+  runs it against a PR number; the run gets a normal write token. `github.event.workflow_run` was
+  never usable for forks (its `pull_requests` array is always empty), so there is no automatic fork
+  path. Note a dispatch runs the workflow file from its target ref (usually `main`), so `k3s.yml`
+  changes in a fork PR are not exercised by the dispatch.
+
+The `pr_info` step resolves the PR number, head/base refs, and head sha — from the event payload for
+`pull_request`, or via `gh pr view` for `workflow_dispatch`. Checkout then uses
+`refs/pull/<n>/merge`.
+
+The image is built in-workflow: `go build` a linux/amd64 binary into `temp/`, `docker build` the
+`Dockerfile`, then `k3d image import` into the cluster. Nothing is pushed to a registry, so the test
+no longer depends on the `Docker build` workflow.
+
+It runs two scenarios: the healthy apps (`EXPECT_EXIT=0`), then — after deleting `meta` (finalizer
+removed first, since its `selfHeal` would resurrect its children) and applying the broken app — the
+failure case (`EXPECT_EXIT=nonzero`, `REQUIRE_LOG="Failed to diff application broken-deployment"`).
+
+Both runs comment on the PR, so their output is visible on the PR under test.

--- a/test/context.md
+++ b/test/context.md
@@ -61,9 +61,15 @@ phase, prints the logs, and compares the container's exit code against `EXPECT_E
   path. Note a dispatch runs the workflow file from its target ref (usually `main`), so `k3s.yml`
   changes in a fork PR are not exercised by the dispatch.
 
+  **Security:** a dispatch checks out and runs PR-authored code (`go build`, `docker build`,
+  `run-argo-diff-pod.sh`) with the job's `pull-requests: write` token. Review the fork's diff before
+  dispatching. The token has no `contents` / `packages` write, which bounds the damage.
+
 The `pr_info` step resolves the PR number, head/base refs, and head sha — from the event payload for
-`pull_request`, or via `gh pr view` for `workflow_dispatch`. Checkout then uses
-`refs/pull/<n>/merge`.
+`pull_request`, or via `gh pr view` for `workflow_dispatch` (which also normalizes `#123` / a PR URL
+to the integer). Checkout uses the resolved **head sha**, not `refs/pull/<n>/merge`: the merge ref is
+absent on a conflicted PR and can move mid-run, and the real diff is computed against the live PR via
+the API anyway.
 
 The image is built in-workflow: `go build` a linux/amd64 binary into `temp/`, `docker build` the
 `Dockerfile`, then `k3d image import` into the cluster. Nothing is pushed to a registry, so the test

--- a/test/run-argo-diff-pod.sh
+++ b/test/run-argo-diff-pod.sh
@@ -45,7 +45,8 @@ spec:
         - name: ARGO_DIFF_COMMENT_PREAMBLE
           value: |
             ## Argo-Diff - Ephemeral Environment Test
-            This argo-diff should have the same output every run
+        - name: ARGO_DIFF_COMMENT_NOTICE
+          value: "This argo-diff should have the same output every run"
         - name: ARGO_DIFF_CONTEXT_STR
           value: "${ARGO_DIFF_CONTEXT_STR}"
         - name: ARGO_DIFF_SKIP_REF_CHECK

--- a/test/run-argo-diff-pod.sh
+++ b/test/run-argo-diff-pod.sh
@@ -4,7 +4,9 @@
 #
 # Required env vars:
 #   POD_NAME_PREFIX       - prefix for the pod name (a timestamp suffix is appended)
-#   IMAGE_TAG             - argo-diff image tag to run
+#   IMAGE                 - full argo-diff image reference to run (e.g. argo-diff:e2e).
+#                          The workflow builds this locally and side-loads it into
+#                          k3d, so the pod uses imagePullPolicy: Never.
 #   ARGO_DIFF_CONTEXT_STR - value for ARGO_DIFF_CONTEXT_STR (commit status / comment context)
 #   ARGO_DIFF_SHA         - commit sha argo-diff should diff against
 #   ARGO_DIFF_HEAD_REF    - PR head branch
@@ -23,7 +25,7 @@
 
 set -euo pipefail
 
-: "${POD_NAME_PREFIX:?}" "${IMAGE_TAG:?}" "${ARGO_DIFF_CONTEXT_STR:?}" \
+: "${POD_NAME_PREFIX:?}" "${IMAGE:?}" "${ARGO_DIFF_CONTEXT_STR:?}" \
   "${ARGO_DIFF_SHA:?}" "${ARGO_DIFF_HEAD_REF:?}" "${ARGO_DIFF_REPOSITORY:?}" \
   "${GITHUB_TOKEN:?}" "${PR_REF:?}" "${EXPECT_EXIT:?}"
 
@@ -40,7 +42,8 @@ spec:
     - name: argo-diff
       command:
         - /app/argo-diff
-      image: ghcr.io/vince-riv/argo-diff:${IMAGE_TAG}
+      image: ${IMAGE}
+      imagePullPolicy: Never
       env:
         - name: ARGO_DIFF_COMMENT_PREAMBLE
           value: |


### PR DESCRIPTION
## Why

`k3s.yml` consumed the `pr-<n>` image that the `Docker build` workflow pushed to ghcr.io, via a `workflow_run` trigger. Fork PRs never produced that image (forks can't push to ghcr.io), and `github.event.workflow_run.pull_requests` is always empty for forks, so the `workflow_run` path could not resolve a fork PR at all.

## What

- **Build the image in `k3s.yml`.** `go build` a linux/amd64 binary, `docker build` the `Dockerfile`, `k3d image import` into the cluster. No registry, no dependency on the `Docker build` workflow.
- **Add a `workflow_dispatch` trigger** with a required `pr` input — the manual path for fork PRs. The run gets a normal write token, so argo-diff can post its PR comment. The input is normalized (`#123` / a PR URL both resolve to the integer via `gh pr view`).
- **`pull_request` trigger skips fork PRs** (read-only token can't comment) via the job `if:`. Its `paths` filter is broadened to Go, `Dockerfile`, and fixture-chart changes to keep the coverage the `workflow_run` chain provided.
- **New `pr_info` step** resolves the PR number, refs, and head sha from the event payload or via `gh pr view`. Checkout uses the resolved **head sha** — the merge ref is absent on a conflicted PR and can move mid-run, and the real diff is computed against the live PR via the API anyway.
- **`run-argo-diff-pod.sh`** takes a full `IMAGE` reference instead of `IMAGE_TAG` and runs the pod with `imagePullPolicy: Never`.
- **`dockerbuild.yml` no longer pushes a per-PR image.** Nothing consumes `pr-<n>` now that k3s.yml builds its own. On `pull_request` it builds the amd64 image with `push: false` (still validates GoReleaser + the Dockerfile); ghcr login, `docker/metadata-action`, and QEMU are gated to non-PR events. Its `pull_request` paths are narrowed to `dockerbuild.yml`, `.goreleaser.yaml`, `Dockerfile` — `go.yml` already covers Go compilation, and `push` to `main` / `release-*` still catches multi-arch breakage. Publishing behavior is unchanged.
- Earlier commit on this branch: move the "same output every run" line from the comment preamble to `ARGO_DIFF_COMMENT_NOTICE`.

## Security

A `workflow_dispatch` run **checks out and runs PR-authored code** (`go build`, `docker build`, `test/run-argo-diff-pod.sh`) with the job's `pull-requests: write` token. A maintainer must review the fork's diff before dispatching. The token has no `contents` / `packages` write, so the blast radius is comment post/edit only. This is called out in a `SECURITY` comment by the `permissions` block, the dispatch input description, and `test/context.md`.

## Limitation

A `workflow_dispatch` run uses the workflow file from `main`, so a fork PR that edits `k3s.yml` itself is not exercised by the dispatch. Fork PRs changing `test/**`, Go code, `Dockerfile`, or the fixture chart are fully tested.

## Verification

Local: `go build ./cmd` and `docker build` both succeed. `actionlint` is clean on `dockerbuild.yml`; on `k3s.yml` it reports 2 findings, both pre-existing in an untouched step (the file had 8 before). `shellcheck test/run-argo-diff-pod.sh` is clean.

Assisted-by: Claude Code (claude-sonnet-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)